### PR TITLE
Fix desktop column-grid overlay layering and visibility

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -390,6 +390,10 @@ body.is-pulling-refresh .rail::after {
   column-gap: var(--grid-gutter);
 }
 
+.content > :not(.grid-overlay) {
+  z-index: 2;
+}
+
 .content > section {
   grid-column: 1 / -1;
   position: relative;
@@ -403,14 +407,14 @@ body.is-pulling-refresh .rail::after {
   grid-template-columns: repeat(var(--grid-cols), minmax(0, 1fr));
   column-gap: var(--grid-gutter);
   pointer-events: none;
-  z-index: 10;
+  z-index: 0;
   opacity: 1;
   visibility: visible;
   transition: opacity 0.28s ease, visibility 0.28s ease;
 }
 
 .grid-overlay > span {
-  background: rgba(255, 255, 255, 0.03);
+  background: rgba(255, 255, 255, 0.08);
   opacity: 1;
   transform: translateY(0) scaleY(1);
   transform-origin: top center;


### PR DESCRIPTION
## Summary
- keep the desktop column-grid overlay under page content
- increase grid overlay tint so toggle-on state is clearly visible

## Changes
- add `.content > :not(.grid-overlay) { z-index: 2; }`
- change `.grid-overlay` `z-index` from `10` to `0`
- change `.grid-overlay > span` background from `rgba(255, 255, 255, 0.03)` to `rgba(255, 255, 255, 0.08)`

Closes #6