### PR TITLE
Fix make/dev-live auto-open host on multi-Mac setups

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -14,6 +14,7 @@
 - Local development workflow improvements
 - Default preview port change from `8000` to `7777`
 - Keep docs aligned with the updated preview defaults
+- Ensure browser auto-open uses each machine's hostname (not `localhost`) in multi-Mac setups
 
 ## What Changed
 - Changed the default Make target port from `8000` to `7777` for `make`, `make dev`, `make dev-local`, and `make dev-live`.
@@ -49,6 +50,8 @@
   - `make dev-live` for auto-refresh on HTML/CSS/JS edits
   - explicit Node runtime guard/help text for older Node 14 setups (`node:path` support)
 - Updated local URL host detection in Make targets to derive `<this-mac>.local` from macOS `LocalHostName` automatically across machines.
+- Expanded hostname fallback logic in Make targets (`LocalHostName` -> `HostName` -> shell hostname -> sanitized `ComputerName`) so browser auto-open avoids `localhost` when possible.
+- Updated `make dev-live` to open the resolved machine hostname explicitly and disable BrowserSync's default auto-open (`--no-open`).
 - Added shared text wrapping rules in `assets/css/styles.css`:
   - `text-wrap: balance` for headings (`h1`-`h6`)
   - `text-wrap: pretty` for paragraphs and list items
@@ -61,9 +64,9 @@
 - Optionally prune unused temporary SVG files (`coming-soon-note.svg` and `*-stroke.svg`) if they are no longer needed.
 
 ## Local Run
-- Network + localhost:
+- Network + this Mac hostname:
   - `make`
-- Network + localhost with live reload:
+- Network + this Mac hostname with live reload:
   - `make dev-live`
 - Localhost-only:
   - `make dev-local`

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,23 @@ dev:
 	if [ "$$LOCAL_URL_HOST" = "localhost" ]; then \
 		MAC_LOCAL_NAME="$$(scutil --get LocalHostName 2>/dev/null || true)"; \
 		if [ -n "$$MAC_LOCAL_NAME" ]; then LOCAL_URL_HOST="$$MAC_LOCAL_NAME.local"; fi; \
+		if [ "$$LOCAL_URL_HOST" = "localhost" ] || [ -z "$$LOCAL_URL_HOST" ]; then \
+			MAC_HOST_NAME="$$(scutil --get HostName 2>/dev/null || true)"; \
+			if [ -n "$$MAC_HOST_NAME" ]; then LOCAL_URL_HOST="$$MAC_HOST_NAME"; fi; \
+		fi; \
+		if [ "$$LOCAL_URL_HOST" = "localhost" ] || [ -z "$$LOCAL_URL_HOST" ]; then \
+			SHELL_HOST_NAME="$$(hostname -s 2>/dev/null || hostname 2>/dev/null || true)"; \
+			if [ -n "$$SHELL_HOST_NAME" ]; then LOCAL_URL_HOST="$$SHELL_HOST_NAME"; fi; \
+		fi; \
+		if [ "$$LOCAL_URL_HOST" = "localhost" ] || [ -z "$$LOCAL_URL_HOST" ]; then \
+			MAC_COMPUTER_NAME="$$(scutil --get ComputerName 2>/dev/null || true)"; \
+			if [ -n "$$MAC_COMPUTER_NAME" ]; then LOCAL_URL_HOST="$$(echo "$$MAC_COMPUTER_NAME" | tr ' ' '-')"; fi; \
+		fi; \
+		case "$$LOCAL_URL_HOST" in \
+			""|localhost) LOCAL_URL_HOST="localhost" ;; \
+			*.*) ;; \
+			*) LOCAL_URL_HOST="$$LOCAL_URL_HOST.local" ;; \
+		esac; \
 	fi; \
 	DEFAULT_IFACE="$$(route -n get default 2>/dev/null | awk '/interface:/{print $$2; exit}')"; \
 	LAN_IP="$$( [ -n "$$DEFAULT_IFACE" ] && ipconfig getifaddr "$$DEFAULT_IFACE" 2>/dev/null || true )"; \
@@ -83,6 +100,23 @@ dev-local:
 	if [ "$$LOCAL_URL_HOST" = "localhost" ]; then \
 		MAC_LOCAL_NAME="$$(scutil --get LocalHostName 2>/dev/null || true)"; \
 		if [ -n "$$MAC_LOCAL_NAME" ]; then LOCAL_URL_HOST="$$MAC_LOCAL_NAME.local"; fi; \
+		if [ "$$LOCAL_URL_HOST" = "localhost" ] || [ -z "$$LOCAL_URL_HOST" ]; then \
+			MAC_HOST_NAME="$$(scutil --get HostName 2>/dev/null || true)"; \
+			if [ -n "$$MAC_HOST_NAME" ]; then LOCAL_URL_HOST="$$MAC_HOST_NAME"; fi; \
+		fi; \
+		if [ "$$LOCAL_URL_HOST" = "localhost" ] || [ -z "$$LOCAL_URL_HOST" ]; then \
+			SHELL_HOST_NAME="$$(hostname -s 2>/dev/null || hostname 2>/dev/null || true)"; \
+			if [ -n "$$SHELL_HOST_NAME" ]; then LOCAL_URL_HOST="$$SHELL_HOST_NAME"; fi; \
+		fi; \
+		if [ "$$LOCAL_URL_HOST" = "localhost" ] || [ -z "$$LOCAL_URL_HOST" ]; then \
+			MAC_COMPUTER_NAME="$$(scutil --get ComputerName 2>/dev/null || true)"; \
+			if [ -n "$$MAC_COMPUTER_NAME" ]; then LOCAL_URL_HOST="$$(echo "$$MAC_COMPUTER_NAME" | tr ' ' '-')"; fi; \
+		fi; \
+		case "$$LOCAL_URL_HOST" in \
+			""|localhost) LOCAL_URL_HOST="localhost" ;; \
+			*.*) ;; \
+			*) LOCAL_URL_HOST="$$LOCAL_URL_HOST.local" ;; \
+		esac; \
 	fi; \
 	echo "Serving local-only: http://$$LOCAL_URL_HOST:$$PORT_TO_USE (Ctrl+C to stop)"; \
 	(sleep 0.8; open "http://$$LOCAL_URL_HOST:$$PORT_TO_USE/") >/dev/null 2>&1 & \
@@ -130,6 +164,23 @@ dev-live:
 	if [ "$$LOCAL_URL_HOST" = "localhost" ]; then \
 		MAC_LOCAL_NAME="$$(scutil --get LocalHostName 2>/dev/null || true)"; \
 		if [ -n "$$MAC_LOCAL_NAME" ]; then LOCAL_URL_HOST="$$MAC_LOCAL_NAME.local"; fi; \
+		if [ "$$LOCAL_URL_HOST" = "localhost" ] || [ -z "$$LOCAL_URL_HOST" ]; then \
+			MAC_HOST_NAME="$$(scutil --get HostName 2>/dev/null || true)"; \
+			if [ -n "$$MAC_HOST_NAME" ]; then LOCAL_URL_HOST="$$MAC_HOST_NAME"; fi; \
+		fi; \
+		if [ "$$LOCAL_URL_HOST" = "localhost" ] || [ -z "$$LOCAL_URL_HOST" ]; then \
+			SHELL_HOST_NAME="$$(hostname -s 2>/dev/null || hostname 2>/dev/null || true)"; \
+			if [ -n "$$SHELL_HOST_NAME" ]; then LOCAL_URL_HOST="$$SHELL_HOST_NAME"; fi; \
+		fi; \
+		if [ "$$LOCAL_URL_HOST" = "localhost" ] || [ -z "$$LOCAL_URL_HOST" ]; then \
+			MAC_COMPUTER_NAME="$$(scutil --get ComputerName 2>/dev/null || true)"; \
+			if [ -n "$$MAC_COMPUTER_NAME" ]; then LOCAL_URL_HOST="$$(echo "$$MAC_COMPUTER_NAME" | tr ' ' '-')"; fi; \
+		fi; \
+		case "$$LOCAL_URL_HOST" in \
+			""|localhost) LOCAL_URL_HOST="localhost" ;; \
+			*.*) ;; \
+			*) LOCAL_URL_HOST="$$LOCAL_URL_HOST.local" ;; \
+		esac; \
 	fi; \
 	DEFAULT_IFACE="$$(route -n get default 2>/dev/null | awk '/interface:/{print $$2; exit}')"; \
 	LAN_IP="$$( [ -n "$$DEFAULT_IFACE" ] && ipconfig getifaddr "$$DEFAULT_IFACE" 2>/dev/null || true )"; \
@@ -138,4 +189,5 @@ dev-live:
 	echo "Live reload on this Mac: http://$$LOCAL_URL_HOST:$$PORT_TO_USE"; \
 	echo "Live reload on your network: http://$$LAN_IP:$$PORT_TO_USE"; \
 	echo "(Ctrl+C to stop)"; \
-	npx browser-sync start --server . --files 'index.html,sendmoi/**/*.html,assets/css/**/*.css,assets/js/**/*.js' --host $(BIND) --port $$PORT_TO_USE
+	(sleep 0.8; open "http://$$LOCAL_URL_HOST:$$PORT_TO_USE/") >/dev/null 2>&1 & \
+	npx browser-sync start --server . --files 'index.html,sendmoi/**/*.html,assets/css/**/*.css,assets/js/**/*.js' --host $(BIND) --port $$PORT_TO_USE --no-open

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ make
 ```
 
 That starts a static server on all interfaces (`0.0.0.0`), prints:
-- `http://<this-mac>.local:7777` for this Mac (derived from macOS `LocalHostName`, for example `http://niederstudio.local:7777`)
+- `http://<this-mac>.local:7777` for this Mac (derived from macOS `LocalHostName` with fallbacks to `HostName`, shell hostname, and sanitized `ComputerName` when needed; for example `http://niederstudio.local:7777`)
 - a LAN URL like `http://192.168.x.x:7777` for other devices on the same network (for example, Niederstudio)
 
 It also opens the `.local` URL on this Mac.
@@ -32,7 +32,7 @@ For auto-refresh in the browser on file save, run:
 make dev-live
 ```
 
-This uses BrowserSync to serve the repo and reload when HTML/CSS/JS files change.
+This uses BrowserSync to serve the repo and reload when HTML/CSS/JS files change. It opens the same resolved `<this-mac>.local` URL as `make dev` instead of BrowserSync's default `localhost`.
 
 Requirements:
 - Node.js with `npx` available (recommended: Node 20 via `nvm use 20`)


### PR DESCRIPTION
## Summary
- expand local URL hostname fallback logic in Make targets (`LocalHostName -> HostName -> hostname -> sanitized ComputerName`)
- keep `.local` suffix handling for bare hostnames
- make `dev-live` open the resolved host URL directly and disable BrowserSync default auto-open (`--no-open`)
- document the behavior updates in `README.md` and `HANDOFF.md`

Closes #8

## Validation
- `make -n dev`
- `make -n dev-live`
