### PR TITLE
Enhancement: add extensible homepage footer

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,67 +1,53 @@
 # Handoff
 
 ## Branch
-- `codex/home-case-study-promo`
+- `codex/enhancement-footer`
 
-## Last Pushed
-- `8fd47ed` `Add safe GitHub issue creation workflow (#12)` (current `main` base before this branch work)
+## Ticket
+- `#17` Enhancement: Add extensible grid footer with policy links
+  - https://github.com/niederme/nieder.me/issues/17
 
 ## Current Focus
-- Finalize and ship reusable homepage case-study promo modules (Resy + SendMoi).
-- Restore standalone `/work/...` case-study pages and align rail nav behaviors/states.
-- Prepare PR against issue `#14`.
+- Add and ship a homepage footer that matches the existing Vignelli/Speakerman grid style.
+- Ensure footer link architecture can grow over time without structural refactors.
 
 ## What Changed
-- Homepage promos (`index.html`, `assets/css/styles.css`, `assets/js/main.js`):
-  - Added reusable case-study promo section after `Work Experience`.
-  - Added Resy and SendMoi promo instances with configurable logo/bg/focus data attributes.
-  - Set `200px` spacing above promo section, `50px` spacing between promo cards, and `50px` promo corner radius.
-  - Updated SendMoi promo copy:
-    - Eyebrow: `SendMoi for iOS & MacOS`
-    - Headline: `Designed & built with a little help from AI coding tools.`
-  - Added desktop side-nav anchors for `Resy` and `SendMoi` and linked them to `#case-study-resy` and `#case-study-sendmoi`.
-  - Updated rail active-state calculation to use document-absolute section tops so one nav item stays active while scrolling.
-  - Nav icon state behavior:
-    - Off state uses provided off assets.
-    - On state uses white `*-on.svg` assets.
-    - Hover uses dedicated red `*-hover.svg` assets.
-    - SendMoi nav icon remains width exception at `32px`.
-- New/updated promo assets:
-  - `assets/images/home/case-study-promos/bg-SendMoi-desktop.png`
-  - `assets/images/home/case-study-promos/logo-SendMoi.svg`
-- Standalone work pages:
-  - Existing Resy page kept and updated to shared stylesheet version `20260310-002`.
-  - Added `work/sendmoi/index.html` from legacy content, adapted to standalone article template.
-  - Extended `assets/css/work-case-study.css` with per-page theme variables (hero image/overlay/focus/logo sizing) used by `work-theme-sendmoi`.
-- Desktop rail icon assets:
-  - Updated from Desktop: `home-off/on`, `icon-work-experience-off/on`.
-  - Added: `icon-work-resy-off/on`, `icon-work-sendmoi-off/on`.
-  - Added hover variants: `home-hover`, `icon-work-experience-hover`, `icon-work-resy-hover`, `icon-work-sendmoi-hover`.
-- Existing cleanup retained:
-  - Defunct `mailmoi/` pages removed.
+- Homepage footer added (`index.html`, `assets/css/styles.css`):
+  - Added a new `site-footer` section after case-study promos.
+  - Added grouped, extensible link columns:
+    - `Case Studies` (internal)
+    - `Connect` (external + email)
+    - `Policies` (privacy/terms/accessibility)
+  - Added footer brand/legal copy block.
+  - Kept desktop alignment on the existing 12-column grid; added responsive tablet/mobile collapse behavior.
+- Email-link behavior generalized (`assets/js/main.js`):
+  - Updated `data-email-link` handling from single element to multiple elements so topper + footer can both use obfuscated mailto links.
+- Cache-bust updates:
+  - Updated homepage CSS/JS query params to `v=20260310-020`.
+- Docs:
+  - Updated `README.md` with a new `Homepage footer` section and implementation notes.
 
 ## Verification
 - `node --check assets/js/main.js` passes.
-- Manual visual QA completed iteratively with user-provided screenshots and Desktop icon/background asset replacements.
+- Manual source review confirms:
+  - Footer is placed after case-study promos.
+  - New footer classes have desktop + responsive mobile rules.
+  - Footer email link uses existing obfuscation setup via `data-email-link`.
 
 ## Open Items
-- Commit all current changes.
-- Push branch and open PR that closes issue `#14`.
+- Visual QA in browser at desktop and mobile breakpoints.
+- Commit, push branch, and open PR referencing issue `#17`.
 
 ## Resume Checklist
 1. `git fetch --all`
-2. `git checkout codex/home-case-study-promo`
+2. `git checkout codex/enhancement-footer`
 3. `git status --short`
 4. Review diffs in:
    - `index.html`
    - `assets/css/styles.css`
    - `assets/js/main.js`
-   - `assets/css/work-case-study.css`
-   - `work/resy-discovery/index.html`
-   - `work/sendmoi/index.html`
-   - `assets/icons/side-nav/*(home|work-*)*`
-   - `assets/images/home/case-study-promos/*SendMoi*`
    - `README.md`
    - `HANDOFF.md`
-5. Commit + push
-6. Open/update PR for issue `#14`
+5. Run `node --check assets/js/main.js`
+6. Commit + push
+7. Open PR and include `Closes #17`

--- a/README.md
+++ b/README.md
@@ -82,6 +82,16 @@ EOF
 - Promo cards use a `50px` corner radius and `50px` vertical spacing between cards.
 - Desktop rail nav on home now includes direct anchors for `Work Experience`, `Resy`, and `SendMoi`, with explicit off/on/hover icon assets.
 
+## Homepage footer
+
+- The homepage now includes a grid-aligned footer after case-study promos using grouped link columns for long-term growth.
+- Footer groups:
+  - `Case Studies` (internal work links)
+  - `Connect` (social + email)
+  - `Policies` (`/sendmoi/privacy/`, `/sendmoi/terms/`, `/sendmoi/accessibility/`)
+- Footer keeps the same visual system (rules, typography scale, spacing) and collapses responsively for tablet/mobile.
+- `data-email-link` now supports multiple anchors so the obfuscated mailto behavior works in both topper social links and footer links.
+
 ## Legacy removal
 
 - The old `mailmoi/` pages were removed from this branch as defunct content.

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -857,6 +857,99 @@ body.grid-hidden .grid-overlay > span {
   opacity: 0.9;
 }
 
+.site-footer {
+  margin-top: 140px;
+  padding-bottom: 72px;
+}
+
+.site-footer > .rule {
+  margin-bottom: 30px;
+}
+
+.site-footer-grid {
+  display: grid;
+  grid-template-columns: repeat(var(--grid-cols), minmax(0, 1fr));
+  column-gap: var(--grid-gutter);
+  row-gap: 30px;
+}
+
+.site-footer-brand {
+  grid-column: 1 / span 4;
+}
+
+.site-footer-column-work {
+  grid-column: 5 / span 3;
+}
+
+.site-footer-column-connect {
+  grid-column: 8 / span 2;
+}
+
+.site-footer-column-policies {
+  grid-column: 10 / span 3;
+}
+
+.site-footer-kicker {
+  margin: 0;
+  color: var(--fg);
+  font-size: 30px;
+  line-height: 1;
+  font-weight: 300;
+  letter-spacing: -0.01em;
+}
+
+.site-footer-note {
+  margin: 10px 0 0;
+  color: var(--muted);
+  font-size: 16px;
+  line-height: 1.35;
+}
+
+.site-footer-meta {
+  margin: 26px 0 0;
+  color: #8e8f98;
+  font-size: 14px;
+  line-height: 1.35;
+}
+
+.site-footer-column h3 {
+  margin: 0;
+  color: var(--fg);
+  font-size: 16px;
+  line-height: 1.1;
+  font-weight: 700;
+}
+
+.site-footer-links {
+  list-style: none;
+  margin: 14px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.site-footer-links li {
+  margin: 0;
+}
+
+.site-footer-links a {
+  color: var(--accent);
+  font-size: 16px;
+  line-height: 1.35;
+  font-weight: 400;
+  text-decoration: none;
+}
+
+.site-footer-links a:visited {
+  color: var(--accent);
+}
+
+.site-footer-links a:hover,
+.site-footer-links a:focus-visible {
+  color: #ff6a60;
+}
+
 .selected-work,
 .how-i-work,
 .contact-cta {
@@ -1511,6 +1604,28 @@ body.grid-hidden .grid-overlay > span {
     font-size: clamp(34px, 5.2vw, 44px);
   }
 
+  .site-footer {
+    margin-top: 92px;
+    padding-bottom: 64px;
+  }
+
+  .site-footer-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    column-gap: 30px;
+    row-gap: 26px;
+  }
+
+  .site-footer-brand,
+  .site-footer-column-work,
+  .site-footer-column-connect,
+  .site-footer-column-policies {
+    grid-column: auto;
+  }
+
+  .site-footer-brand {
+    grid-column: 1 / -1;
+  }
+
   .experience-grid {
     grid-template-columns: 1fr;
     row-gap: 28px;
@@ -1703,6 +1818,20 @@ body.grid-hidden .grid-overlay > span {
     font-size: 16px;
   }
 
+  .site-footer {
+    margin-top: 72px;
+    padding-bottom: 54px;
+  }
+
+  .site-footer-grid {
+    grid-template-columns: 1fr;
+    row-gap: 22px;
+  }
+
+  .site-footer-kicker {
+    font-size: 27px;
+  }
+
   .job-header h3 {
     font-size: clamp(48px, 16vw, 84px);
   }
@@ -1835,6 +1964,7 @@ body.grid-hidden .grid-overlay > span {
   .job-header > .rule,
   .case-study > .rule,
   .work-experience > .rule,
+  .site-footer > .rule,
   .selected-work > .rule,
   .how-i-work > .rule,
   .contact-cta > .rule {
@@ -2304,6 +2434,7 @@ body.grid-hidden .grid-overlay > span {
 
   .experience-heading,
   .experience-column,
+  .site-footer-grid,
   .section-head,
   .selected-work-grid,
   .how-i-work-grid,

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,7 +1,7 @@
 const caseNav = document.querySelector(".case-nav");
 const logoMarks = Array.from(document.querySelectorAll(".logo-mark, .mobile-logo-mark"));
 const colsToggles = Array.from(document.querySelectorAll(".cols-toggle"));
-const emailLink = document.querySelector("[data-email-link]");
+const emailLinks = Array.from(document.querySelectorAll("[data-email-link]"));
 const COLS_TOGGLE_STORAGE_KEY = "nieder.cols-grid-visible";
 const scrollToPageTop = () => {
   window.scrollTo({ top: 0, behavior: "smooth" });
@@ -14,11 +14,13 @@ const scrollToPageTop = () => {
   }
 };
 
-if (emailLink) {
+if (emailLinks.length > 0) {
   const emailAddress = String.fromCharCode(
     106, 111, 104, 110, 64, 110, 105, 101, 100, 101, 114, 46, 109, 101
   );
-  emailLink.href = `mailto:${emailAddress}`;
+  emailLinks.forEach((emailLink) => {
+    emailLink.href = `mailto:${emailAddress}`;
+  });
 }
 
 {

--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
     <meta name="twitter:url" content="https://nieder.me/2026/" />
     <meta name="twitter:image" content="https://nieder.me/2026/assets/images/share/og-image-1200x630.png" />
     <meta name="twitter:image:alt" content="Preview of John Niedermeyer's product design portfolio." />
-    <link rel="stylesheet" href="assets/css/styles.css?v=20260310-019" />
+    <link rel="stylesheet" href="assets/css/styles.css?v=20260310-020" />
   </head>
   <body id="top">
     <div class="page">
@@ -295,8 +295,47 @@
           </article>
         </section>
 
+        <footer class="site-footer" aria-label="Site footer">
+          <div class="rule"></div>
+          <div class="site-footer-grid">
+            <div class="site-footer-brand">
+              <p class="site-footer-kicker">Nieder.me</p>
+              <p class="site-footer-note">Product Design &amp; Direction</p>
+              <p class="site-footer-meta">© 2026 John Niedermeyer. Built to evolve.</p>
+            </div>
+
+            <nav class="site-footer-column site-footer-column-work" aria-label="Case studies">
+              <h3>Case Studies</h3>
+              <ul class="site-footer-links">
+                <li><a href="work/resy-discovery/">Resy Discovery</a></li>
+                <li><a href="work/sendmoi/">SendMoi</a></li>
+              </ul>
+            </nav>
+
+            <nav class="site-footer-column site-footer-column-connect" aria-label="Connect links">
+              <h3>Connect</h3>
+              <ul class="site-footer-links">
+                <li><a href="https://github.com/niederme/" target="_blank" rel="noopener noreferrer">GitHub</a></li>
+                <li><a href="https://www.linkedin.com/in/niederme/" target="_blank" rel="noopener noreferrer">LinkedIn</a></li>
+                <li><a href="https://x.com/niederme/" target="_blank" rel="noopener noreferrer">X</a></li>
+                <li><a href="https://instagram.com/niederme/" target="_blank" rel="noopener noreferrer">Instagram</a></li>
+                <li><a data-email-link aria-label="Send email">Email</a></li>
+              </ul>
+            </nav>
+
+            <nav class="site-footer-column site-footer-column-policies" aria-label="Policy links">
+              <h3>Policies</h3>
+              <ul class="site-footer-links">
+                <li><a href="/sendmoi/privacy/">Privacy</a></li>
+                <li><a href="/sendmoi/terms/">Terms</a></li>
+                <li><a href="/sendmoi/accessibility/">Accessibility</a></li>
+              </ul>
+            </nav>
+          </div>
+        </footer>
+
       </main>
     </div>
-    <script src="assets/js/main.js?v=20260310-019"></script>
+    <script src="assets/js/main.js?v=20260310-020"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add a new homepage footer after case-study promos, aligned to the existing grid language
- add growable footer link groups: Case Studies, Connect, and Policies
- generalize `data-email-link` handling so email obfuscation works for multiple links
- update homepage cache-bust versions for CSS/JS
- update README and HANDOFF for the new footer workflow

## Verification
- node --check assets/js/main.js

Closes #17