### PR TITLE
Document feature-branch-first workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,17 +1,16 @@
 # Repository Instructions
 
+## Feature Branch First
+- Before writing code, editing files, or starting implementation work, run `git branch --show-current`.
+- If you are on `main`, create or switch to a feature branch before making changes.
+- Do not treat `main` as a working branch for active development.
+- Preferred workflow: create a dedicated `git worktree` for each active feature branch/thread.
+
 ## Commit Workflow
 - Before every commit, review `README.md` and `HANDOFF.md`.
 - Update `README.md` whenever setup steps, commands, behavior, or other user-facing documentation changed.
 - Update `HANDOFF.md` whenever the working branch, current focus, recent changes, open items, or resume steps changed.
 - Do not finalize a commit until those files are either updated or explicitly confirmed to still be accurate.
-
-## Thread/Branch Isolation
-- Assume Codex threads share a single Git worktree unless explicitly separated.
-- Before any git operation, run `git branch --show-current` and verify it matches the task branch.
-- If the branch does not match the expected branch, stop and ask the user before switching.
-- Do not run `git checkout`, `git pull`, or `git merge` on a different branch without explicit user approval.
-- Preferred workflow: use `git worktree` with one directory per active thread/feature branch.
 
 ## Thread/Branch Isolation
 - Assume Codex threads share a single Git worktree unless explicitly separated.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,35 +1,26 @@
 # Handoff
 
 ## Branch
-- `main`
+- `codex/feature-branch-process`
 
 ## Current Focus
-- Homepage mobile work-experience carousel polish.
+- Make the repo lifecycle docs explicitly require feature-branch work before implementation.
 
 ## What Changed
-- Wrapped the two homepage work-experience columns in a mobile carousel container with mobile page dots.
-- Added mobile-only carousel sizing and scroll-snap rules so the second column peeks in like the topper cards.
-- Corrected the carousel track offset so both columns snap to the same left text edge.
-- Bumped homepage asset query params in `index.html`:
-  - `assets/css/styles.css?v=20260310-030`
-  - `assets/js/main.js?v=20260310-030`
+- Added a `Feature Branch First` section to `AGENTS.md`.
+- Made the rule explicit that implementation work must not begin on `main`.
+- Added a matching `Development workflow` section to `README.md` with branch/worktree examples.
+- Removed the duplicated `Thread/Branch Isolation` section from `AGENTS.md`.
 
 ## Verification
-- `git diff` confirms the homepage work-experience markup/CSS changes plus cache-bust token updates.
+- `git diff` should show doc-only changes in `AGENTS.md`, `README.md`, and `HANDOFF.md`.
 
 ## Open Items
-- Commit and push `main`.
-- Run `./scripts/deploy-2026.sh` from a shell with deploy SSH credentials loaded.
-- Verify the mobile work-experience carousel on iPhone Safari after deploy.
+- Commit and push the docs update branch.
+- If desired, cherry-pick or merge the docs update back after review.
 
 ## Resume Checklist
 1. `git branch --show-current`
 2. `git status --short`
-3. Commit and push `main`
-4. Run deploy:
-   - `./scripts/deploy-2026.sh`
-5. Verify:
-   - Homepage `Work Experience` carousel behavior on mobile Safari
-   - `https://nieder.me/2026/work/`
-   - `https://nieder.me/2026/work/resy-discovery/`
-   - `https://nieder.me/2026/work/sendmoi/`
+3. Review `AGENTS.md` and `README.md`
+4. Commit and push `codex/feature-branch-process`

--- a/README.md
+++ b/README.md
@@ -24,6 +24,30 @@ make dev PORT=8080
 
 `make dev-lan` is available as an alias of `make dev`.
 
+## Development workflow
+
+Before starting implementation work:
+
+```bash
+git branch --show-current
+```
+
+- If you are on `main`, create or switch to a feature branch before editing files.
+- Do not use `main` as the active development branch.
+- Preferred workflow: use a dedicated `git worktree` per feature branch/thread.
+
+Example:
+
+```bash
+git switch -c codex/my-feature
+```
+
+Or, for isolated parallel work:
+
+```bash
+git worktree add ../nieder-me-my-feature -b codex/my-feature
+```
+
 ## Live reload
 
 For auto-refresh in the browser on file save, run:


### PR DESCRIPTION
## Summary
- require creating or switching to a feature branch before implementation work begins
- add matching development-workflow guidance to the README with branch/worktree examples
- remove the duplicated thread/branch isolation section from AGENTS.md

## Notes
- this PR is docs-only
- there is an unrelated unstaged local change in `index.html` in the worktree that is not included in this PR