### PR TITLE
Refine homepage mobile carousel alignment

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,26 +1,38 @@
 # Handoff
 
 ## Branch
-- `codex/feature-branch-process`
+- `codex/mobile-carousel-alignment`
 
 ## Current Focus
-- Make the repo lifecycle docs explicitly require feature-branch work before implementation.
+- Finish and package homepage mobile carousel alignment and touch-hover polish for merge.
 
 ## What Changed
-- Added a `Feature Branch First` section to `AGENTS.md`.
-- Made the rule explicit that implementation work must not begin on `main`.
-- Added a matching `Development workflow` section to `README.md` with branch/worktree examples.
-- Removed the duplicated `Thread/Branch Isolation` section from `AGENTS.md`.
+- Updated the homepage mobile topper carousel to use a responsive snap inset tied to `--mobile-content-width`.
+- Narrowed follow-on topper cards slightly so the middle card still hints at the third card.
+- Updated the homepage mobile `Work Experience` carousel to use the same responsive snap-inset model.
+- Scoped link hover-only underline styles to hover-capable devices to avoid sticky touch hover artifacts on iPhone.
+- Updated homepage work-experience copy:
+  - `Design Lead, Digital News Design` → `Design Lead`
+  - `Nov. 2007 - Mar. 2012` → `Nov. 2007 - Jan. 2014`
+- Bumped homepage stylesheet cache token in `index.html`:
+  - `assets/css/styles.css?v=20260311-001`
 
 ## Verification
-- `git diff` should show doc-only changes in `AGENTS.md`, `README.md`, and `HANDOFF.md`.
+- Verified locally with Playwright mobile screenshots against a local server for:
+  - topper cards 1, 2, and 3 on `iPhone 14`
+  - topper card 2 on `iPhone SE`
+  - topper card 3 on `iPhone 14 Plus`
+  - `Work Experience` card 2 on `iPhone SE`, `iPhone 14`, and `iPhone 14 Plus`
+- Confirmed the final topper third card reaches the same left snap edge as cards 1 and 2.
 
 ## Open Items
-- Commit and push the docs update branch.
-- If desired, cherry-pick or merge the docs update back after review.
+- Commit and push `codex/mobile-carousel-alignment`.
+- Open PR and merge after review.
+- After merge, clean up the branch and sync local `main`.
 
 ## Resume Checklist
 1. `git branch --show-current`
 2. `git status --short`
-3. Review `AGENTS.md` and `README.md`
-4. Commit and push `codex/feature-branch-process`
+3. Review `README.md` and `HANDOFF.md`
+4. Commit and push `codex/mobile-carousel-alignment`
+5. Open PR to `main`

--- a/README.md
+++ b/README.md
@@ -150,7 +150,10 @@ The deploy script now syncs `index.html`, `assets/`, and (when present) `work/` 
 
 - The mobile-specific section dropdown nav has been removed from the homepage.
 - The mobile topper and case-study stack now use responsive width rules between narrower and wider phone viewports instead of a fixed 375px-only layout.
+- The mobile topper carousel now uses responsive snap insets so cards 1, 2, and 3 align to the same left text edge, while the middle card still leaves a visible hint of the next card.
 - The homepage `Work Experience` section now collapses into a two-panel horizontal carousel on phones, with mobile page dots and a partial peek of the next column.
+- The homepage mobile carousels now compute their snap inset from the shared content width instead of a fixed left offset, which keeps alignment consistent across different phone widths.
 - The mobile horizontal scrollers no longer force `pan-x` only, which reduces vertical scroll lock/jumping during touch interactions.
+- Homepage company-link hover underlines now only apply on hover-capable devices, avoiding sticky touch hover states on iPhone.
 - The mobile top inset and logo-to-heading spacing were tightened to better match the Figma mobile frame.
-- CSS and JS assets use cache-busting query params in `index.html` (`v=20260310-030` on the homepage); if Safari looks stale after changes, do a hard refresh.
+- CSS and JS assets use cache-busting query params in `index.html` (`styles.css?v=20260311-001` on the homepage); if Safari looks stale after changes, do a hard refresh.

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -80,7 +80,6 @@ a:visited {
   color: var(--accent);
 }
 
-a:hover,
 a:focus-visible {
   color: #ff6a60;
 }
@@ -584,7 +583,6 @@ body.grid-hidden .grid-overlay > span {
   transition: border-color 0.18s ease;
 }
 
-.topper-company-link:hover,
 .topper-company-link:focus-visible {
   color: var(--accent);
   border-bottom-color: rgba(255, 69, 58, 0.65);
@@ -705,10 +703,25 @@ body.grid-hidden .grid-overlay > span {
   transition: border-color 0.18s ease;
 }
 
-.experience-item .experience-company a:hover,
 .experience-item .experience-company a:focus-visible {
   color: inherit;
   border-bottom-color: rgba(255, 69, 58, 0.65);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  a:hover {
+    color: #ff6a60;
+  }
+
+  .topper-company-link:hover {
+    color: var(--accent);
+    border-bottom-color: rgba(255, 69, 58, 0.65);
+  }
+
+  .experience-item .experience-company a:hover {
+    color: inherit;
+    border-bottom-color: rgba(255, 69, 58, 0.65);
+  }
 }
 
 .experience-item .experience-date {
@@ -2091,19 +2104,21 @@ body.grid-hidden .grid-overlay > span {
   }
 
   .topper-columns {
+    --topper-track-inset: calc((100vw - var(--mobile-content-width)) / 2);
     --topper-card-1: min(325px, calc(100vw - 50px));
-    --topper-card-n: min(396px, calc(100vw - 30px));
+    --topper-card-n: min(382px, calc(100vw - 48px));
     display: flex;
     align-items: flex-start;
     gap: 15px;
-    width: var(--mobile-topper-width);
-    max-width: var(--mobile-topper-width);
-    margin: 0 -5px 0 10px;
-    padding: 17px 0 0 15px;
+    width: calc(100% + 10px);
+    max-width: none;
+    margin: 0 -5px;
+    padding: 17px 0 0 var(--topper-track-inset);
     min-height: 131px;
     overflow-x: auto;
     overflow-y: hidden;
     scroll-snap-type: x mandatory;
+    scroll-padding-left: var(--topper-track-inset);
     -webkit-overflow-scrolling: touch;
     overscroll-behavior-x: contain;
     touch-action: auto;
@@ -2136,8 +2151,6 @@ body.grid-hidden .grid-overlay > span {
     width: var(--topper-card-n);
     max-width: var(--topper-card-n);
     min-height: 110px;
-    padding-left: 24px;
-    box-sizing: border-box;
   }
 
   .topper-columns p,
@@ -2291,6 +2304,7 @@ body.grid-hidden .grid-overlay > span {
   }
 
   .experience-columns-carousel {
+    --experience-track-inset: calc((100vw - var(--mobile-content-width)) / 2);
     --experience-card-1: min(325px, calc(100vw - 50px));
     --experience-card-n: min(396px, calc(100vw - 30px));
     display: flex;
@@ -2299,12 +2313,12 @@ body.grid-hidden .grid-overlay > span {
     width: calc(100% + 10px);
     max-width: none;
     margin: 0 -5px;
-    padding-left: 15px;
+    padding-left: var(--experience-track-inset);
     box-sizing: border-box;
     overflow-x: auto;
     overflow-y: hidden;
     scroll-snap-type: x mandatory;
-    scroll-padding-left: 15px;
+    scroll-padding-left: var(--experience-track-inset);
     -webkit-overflow-scrolling: touch;
     overscroll-behavior-x: contain;
     touch-action: auto;

--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
     <meta name="twitter:url" content="https://nieder.me/2026/" />
     <meta name="twitter:image" content="https://nieder.me/2026/assets/images/share/og-image-1200x630.png" />
     <meta name="twitter:image:alt" content="Preview of John Niedermeyer's product design portfolio." />
-    <link rel="stylesheet" href="assets/css/styles.css?v=20260310-030" />
+    <link rel="stylesheet" href="assets/css/styles.css?v=20260311-001" />
   </head>
   <body id="top">
     <div class="page">
@@ -179,9 +179,9 @@
                 </article>
 
                 <article class="experience-item">
-                  <h4>Design Lead, Digital News Design</h4>
+                  <h4>Design Lead</h4>
                   <p class="experience-company"><a href="https://nytimes.com" target="_blank" rel="noopener noreferrer">The New York Times</a></p>
-                  <p class="experience-date">Nov. 2007 - Mar. 2012</p>
+                  <p class="experience-date">Nov. 2007 - Jan. 2014</p>
                   <p>Designed NYT Real Estate listings iOS app, and The Scoop, an Arts and Leisure-focused iOS app; rebranded and designed The Opinion Pages section, featuring the first NYT use of branded typography (via Typekit).</p>
                 </article>
 


### PR DESCRIPTION
## Summary
- align the mobile topper and work-experience carousels to the shared content gutter across phone widths
- preserve a visible peek into the next topper card while keeping the final card aligned
- limit company-link hover underline styles to hover-capable devices and update the NYT design-lead copy

## Verification
- verified locally with Playwright mobile screenshots against a local server
- checked topper cards 1, 2, and 3 on iPhone 14
- checked topper card 2 on iPhone SE
- checked topper card 3 on iPhone 14 Plus
- checked Work Experience card 2 on iPhone SE, iPhone 14, and iPhone 14 Plus