### PR TITLE
Keep topper commas with linked companies

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,38 +1,26 @@
 # Handoff
 
 ## Branch
-- `codex/mobile-carousel-alignment`
+- `codex/comma-wrap-hotfix`
 
 ## Current Focus
-- Finish and package homepage mobile carousel alignment and touch-hover polish for merge.
+- Hotfix the topper company-link punctuation so commas stay attached to the linked company names on line wrap.
 
 ## What Changed
-- Updated the homepage mobile topper carousel to use a responsive snap inset tied to `--mobile-content-width`.
-- Narrowed follow-on topper cards slightly so the middle card still hints at the third card.
-- Updated the homepage mobile `Work Experience` carousel to use the same responsive snap-inset model.
-- Scoped link hover-only underline styles to hover-capable devices to avoid sticky touch hover artifacts on iPhone.
-- Updated homepage work-experience copy:
-  - `Design Lead, Digital News Design` → `Design Lead`
-  - `Nov. 2007 - Mar. 2012` → `Nov. 2007 - Jan. 2014`
-- Bumped homepage stylesheet cache token in `index.html`:
-  - `assets/css/styles.css?v=20260311-001`
+- Moved the commas for `The New York Times`, `BuzzFeed`, and `Resy (at American Express)` inside the linked text in the homepage topper copy.
+- This keeps punctuation from wrapping onto its own line at the start of the next line on narrow mobile screens.
 
 ## Verification
-- Verified locally with Playwright mobile screenshots against a local server for:
-  - topper cards 1, 2, and 3 on `iPhone 14`
-  - topper card 2 on `iPhone SE`
-  - topper card 3 on `iPhone 14 Plus`
-  - `Work Experience` card 2 on `iPhone SE`, `iPhone 14`, and `iPhone 14 Plus`
-- Confirmed the final topper third card reaches the same left snap edge as cards 1 and 2.
+- `git diff` shows a single-content hotfix in `index.html`.
 
 ## Open Items
-- Commit and push `codex/mobile-carousel-alignment`.
+- Commit and push `codex/comma-wrap-hotfix`.
 - Open PR and merge after review.
-- After merge, clean up the branch and sync local `main`.
+- After merge, restore or re-apply the stashed deploy/cache-bust work only if still needed.
 
 ## Resume Checklist
 1. `git branch --show-current`
 2. `git status --short`
 3. Review `README.md` and `HANDOFF.md`
-4. Commit and push `codex/mobile-carousel-alignment`
+4. Commit and push `codex/comma-wrap-hotfix`
 5. Open PR to `main`

--- a/index.html
+++ b/index.html
@@ -90,9 +90,9 @@
             </p>
             <p>
               Two decades steering design for industry-defining brands including
-              <a class="topper-company-link" href="https://nytimes.com" target="_blank" rel="noopener noreferrer">The New York Times</a>,
-              <a class="topper-company-link" href="https://buzzfeed.com" target="_blank" rel="noopener noreferrer">BuzzFeed</a>, and
-              <a class="topper-company-link" href="https://resy.com" target="_blank" rel="noopener noreferrer">Resy (at American Express)</a>,
+              <a class="topper-company-link" href="https://nytimes.com" target="_blank" rel="noopener noreferrer">The New York Times,</a>
+              <a class="topper-company-link" href="https://buzzfeed.com" target="_blank" rel="noopener noreferrer">BuzzFeed,</a> and
+              <a class="topper-company-link" href="https://resy.com" target="_blank" rel="noopener noreferrer">Resy (at American Express),</a>
               scaling products from high-growth startups, to global enterprise platforms, with a consistent focus on craft and usability.
             </p>
             <p>


### PR DESCRIPTION
## Summary
- move the commas for The New York Times, BuzzFeed, and Resy (at American Express) inside the linked text in the homepage topper
- prevent the comma from wrapping onto its own line on narrow mobile widths

## Verification
- inspected the resulting diff in `index.html`
- confirmed this PR is limited to the topper copy hotfix and handoff update