### PR TITLE
Stage deploy cache busting outside tracked source

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,26 +1,33 @@
 # Handoff
 
 ## Branch
-- `codex/comma-wrap-hotfix`
+- `codex/deploy-staged-cache-bust`
 
 ## Current Focus
-- Hotfix the topper company-link punctuation so commas stay attached to the linked company names on line wrap.
+- Stop deploy from mutating tracked source files when updating site metadata and cache-busted asset URLs.
 
 ## What Changed
-- Moved the commas for `The New York Times`, `BuzzFeed`, and `Resy (at American Express)` inside the linked text in the homepage topper copy.
-- This keeps punctuation from wrapping onto its own line at the start of the next line on narrow mobile screens.
+- Updated `scripts/deploy-2026.sh` to build a temporary staging directory for deploy output instead of rewriting tracked source files in place.
+- Updated `scripts/set-site-url.sh` to accept an optional HTML target path so deploy can rewrite metadata in the staged `index.html`.
+- Switched deploy-time cache busting from date-sequence tokens stored in source to per-file content hashes computed from the staged CSS and JS assets.
+- Updated `README.md` deploy documentation to reflect the staged deploy flow and non-mutating cache-bust behavior.
 
 ## Verification
-- `git diff` shows a single-content hotfix in `index.html`.
+- Verified with a mocked deploy run using fake `ssh`/`rsync` wrappers:
+  - the worktree stayed unchanged before and after the deploy script ran
+  - the staged `index.html` received rewritten site metadata for the provided `SITE_URL`
+  - the staged `index.html` received hashed cache-bust query params for `styles.css` and `main.js`
 
 ## Open Items
-- Commit and push `codex/comma-wrap-hotfix`.
+- GitHub issue: `#25 Stop deploy from mutating tracked index.html`
+- Commit and push `codex/deploy-staged-cache-bust`.
 - Open PR and merge after review.
-- After merge, restore or re-apply the stashed deploy/cache-bust work only if still needed.
+- Decide whether to drop the stale stash after this branch lands.
 
 ## Resume Checklist
 1. `git branch --show-current`
 2. `git status --short`
 3. Review `README.md` and `HANDOFF.md`
-4. Commit and push `codex/comma-wrap-hotfix`
-5. Open PR to `main`
+4. Verify mocked deploy leaves the worktree clean
+5. Commit and push `codex/deploy-staged-cache-bust`
+6. Open PR to `main`

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Run:
 ./scripts/deploy-2026.sh
 ```
 
-The deploy script now syncs `index.html`, `assets/`, and (when present) `work/` and `sendmoi/`, so `/2026/work/...` routes are published alongside homepage updates.
+The deploy script stages a temporary copy of `index.html`, `assets/`, and (when present) `work/` and `sendmoi/`, rewrites the site metadata and cache-busted asset URLs there, and syncs that staged copy to the server. It does not mutate the tracked source files in your worktree.
 
 ## SendMoi pages
 
@@ -156,4 +156,4 @@ The deploy script now syncs `index.html`, `assets/`, and (when present) `work/` 
 - The mobile horizontal scrollers no longer force `pan-x` only, which reduces vertical scroll lock/jumping during touch interactions.
 - Homepage company-link hover underlines now only apply on hover-capable devices, avoiding sticky touch hover states on iPhone.
 - The mobile top inset and logo-to-heading spacing were tightened to better match the Figma mobile frame.
-- CSS and JS assets use cache-busting query params in `index.html` (`styles.css?v=20260311-001` on the homepage); if Safari looks stale after changes, do a hard refresh.
+- CSS and JS assets use deploy-time cache-busting query params in the staged homepage HTML; if Safari looks stale locally, do a hard refresh.

--- a/scripts/deploy-2026.sh
+++ b/scripts/deploy-2026.sh
@@ -30,44 +30,36 @@ if [[ "$DRY_RUN" == "1" ]]; then
   RSYNC_ARGS+=(--dry-run)
 fi
 
-./scripts/set-site-url.sh "$SITE_URL"
+STAGING_DIR="$(mktemp -d "${TMPDIR:-/tmp}/deploy-2026.XXXXXX")"
+cleanup() {
+  rm -rf "$STAGING_DIR"
+}
+trap cleanup EXIT
 
-# Auto-bump asset cache-bust query string in index.html:
-# assets/css/styles.css?v=YYYYMMDD-###
-# assets/js/main.js?v=YYYYMMDD-###
-today="$(date +%Y%m%d)"
-existing_version="$(grep -Eo 'assets/css/styles\.css\?v=[0-9]{8}-[0-9]{3}' index.html | head -n1 | sed -E 's#.*\?v=##' || true)"
-next_seq=1
-
-if [[ "$existing_version" =~ ^([0-9]{8})-([0-9]{3})$ ]]; then
-  existing_date="${BASH_REMATCH[1]}"
-  existing_seq="${BASH_REMATCH[2]}"
-  if [[ "$existing_date" == "$today" ]]; then
-    next_seq=$((10#$existing_seq + 1))
-  fi
+cp index.html "$STAGING_DIR/"
+cp -R assets "$STAGING_DIR/"
+if [[ -d work ]]; then
+  cp -R work "$STAGING_DIR/"
+fi
+if [[ -d sendmoi ]]; then
+  cp -R sendmoi "$STAGING_DIR/"
 fi
 
-new_css_version="$(printf "%s-%03d" "$today" "$next_seq")"
-perl -0pi -e "s#href=\"assets/css/styles\\.css(?:\\?v=[0-9]{8}-[0-9]{3})?\"#href=\"assets/css/styles.css?v=${new_css_version}\"#g" index.html
-perl -0pi -e "s#src=\"assets/js/main\\.js(?:\\?v=[0-9]{8}-[0-9]{3})?\"#src=\"assets/js/main.js?v=${new_css_version}\"#g" index.html
-echo "Using asset cache-bust version: ${new_css_version}"
+./scripts/set-site-url.sh "$SITE_URL" "$STAGING_DIR/index.html"
+
+css_cache_bust="$(shasum -a 256 "$STAGING_DIR/assets/css/styles.css" | awk '{print substr($1, 1, 12)}')"
+js_cache_bust="$(shasum -a 256 "$STAGING_DIR/assets/js/main.js" | awk '{print substr($1, 1, 12)}')"
+perl -0pi -e "s#href=\"assets/css/styles\\.css(?:\\?v=[^\"]+)?\"#href=\"assets/css/styles.css?v=${css_cache_bust}\"#g" "$STAGING_DIR/index.html"
+perl -0pi -e "s#src=\"assets/js/main\\.js(?:\\?v=[^\"]+)?\"#src=\"assets/js/main.js?v=${js_cache_bust}\"#g" "$STAGING_DIR/index.html"
+echo "Using staged asset cache-bust versions: styles.css?v=${css_cache_bust}, main.js?v=${js_cache_bust}"
 
 REMOTE="${DEPLOY_USER}@${DEPLOY_HOST}:${DEPLOY_PATH%/}/"
 
 # Ensure remote target exists.
 ssh -p "$DEPLOY_PORT" "${DEPLOY_USER}@${DEPLOY_HOST}" "mkdir -p '${DEPLOY_PATH%/}'"
 
-# Sync site files and folders needed for /2026.
-SYNC_PATHS=(index.html assets)
-if [[ -d work ]]; then
-  SYNC_PATHS+=(work)
-fi
-if [[ -d sendmoi ]]; then
-  SYNC_PATHS+=(sendmoi)
-fi
-
 rsync "${RSYNC_ARGS[@]}" -e "ssh -p $DEPLOY_PORT" \
-  "${SYNC_PATHS[@]}" \
+  "$STAGING_DIR"/ \
   "$REMOTE"
 
 echo "Deploy complete -> $REMOTE"

--- a/scripts/set-site-url.sh
+++ b/scripts/set-site-url.sh
@@ -1,20 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ $# -ne 1 ]]; then
-  echo "Usage: $0 <site-url>" >&2
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  echo "Usage: $0 <site-url> [html-file]" >&2
   exit 1
 fi
 
 site_url="${1%/}"
+html_file="${2:-index.html}"
 page_url="${site_url}/"
 image_url="${site_url}/assets/images/share/og-image-1200x630.png"
 
-perl -0pi -e "s#<link rel=\"canonical\" href=\"[^\"]*\" />#<link rel=\"canonical\" href=\"${page_url}\" />#g" index.html
-perl -0pi -e "s#<meta property=\"og:url\" content=\"[^\"]*\" />#<meta property=\"og:url\" content=\"${page_url}\" />#g" index.html
-perl -0pi -e "s#<meta property=\"og:image\" content=\"[^\"]*\" />#<meta property=\"og:image\" content=\"${image_url}\" />#g" index.html
-perl -0pi -e "s#<meta property=\"og:image:secure_url\" content=\"[^\"]*\" />#<meta property=\"og:image:secure_url\" content=\"${image_url}\" />#g" index.html
-perl -0pi -e "s#<meta name=\"twitter:url\" content=\"[^\"]*\" />#<meta name=\"twitter:url\" content=\"${page_url}\" />#g" index.html
-perl -0pi -e "s#<meta name=\"twitter:image\" content=\"[^\"]*\" />#<meta name=\"twitter:image\" content=\"${image_url}\" />#g" index.html
+perl -0pi -e "s#<link rel=\"canonical\" href=\"[^\"]*\" />#<link rel=\"canonical\" href=\"${page_url}\" />#g" "$html_file"
+perl -0pi -e "s#<meta property=\"og:url\" content=\"[^\"]*\" />#<meta property=\"og:url\" content=\"${page_url}\" />#g" "$html_file"
+perl -0pi -e "s#<meta property=\"og:image\" content=\"[^\"]*\" />#<meta property=\"og:image\" content=\"${image_url}\" />#g" "$html_file"
+perl -0pi -e "s#<meta property=\"og:image:secure_url\" content=\"[^\"]*\" />#<meta property=\"og:image:secure_url\" content=\"${image_url}\" />#g" "$html_file"
+perl -0pi -e "s#<meta name=\"twitter:url\" content=\"[^\"]*\" />#<meta name=\"twitter:url\" content=\"${page_url}\" />#g" "$html_file"
+perl -0pi -e "s#<meta name=\"twitter:image\" content=\"[^\"]*\" />#<meta name=\"twitter:image\" content=\"${image_url}\" />#g" "$html_file"
 
-echo "Updated index.html metadata for ${page_url}"
+echo "Updated ${html_file} metadata for ${page_url}"


### PR DESCRIPTION
Closes #25

## Summary
- stage a temporary deploy copy instead of rewriting tracked source files in place
- update `set-site-url.sh` so deploy can target the staged `index.html`
- replace source-stored cache-bust counters with staged CSS/JS content hashes
- document the new deploy behavior in the README and handoff notes

## Verification
- ran `./scripts/deploy-2026.sh` in a mocked dry-run setup with fake `ssh` and `rsync` wrappers
- confirmed `git status` was unchanged before and after the deploy script ran
- confirmed the staged `index.html` received rewritten site metadata and hashed asset query params