### PR TITLE
Add manual light mode toggle

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,34 +1,36 @@
 # Handoff
 
 ## Branch
-- `codex/focus-states`
+- `codex/light-mode-toggle`
 
 ## Current Focus
-- Ship the bundled focus/browser-hint tweaks on this branch via PR for issue `#32`.
+- Ship the manual light-mode toggle on this branch via PR for issue `#36`.
 
 ## What Changed
-- Opened GitHub issue `#32` to track site-wide focus-state cleanup.
-- Added shared focus design tokens in `assets/css/styles.css` and `assets/css/work-case-study.css`.
-- Replaced the browser-default focus treatment with a subdued red `:focus-visible` outline across interactive elements.
-- Added a separate soft red outer glow to control-style elements, including the spinning logo, rail nav controls, social icons, cards, CTA buttons, and the `cols` toggle.
-- Left the existing hover/focus icon swaps and text-color changes intact so the new focus treatment layers on top of current interaction cues.
-- Declared the site dark-only at the document/CSS root level, and all home/work pages now declare a black `theme-color`.
-- Updated `README.md` to document the shared focus treatment.
+- Opened GitHub issue `#36` to track a manual light-mode toggle with a hard dark default.
+- Added a new `light` rail toggle to the homepage, `/work`, `/work/resy-discovery/`, and `/work/sendmoi/`, positioned directly above the existing `cols` toggle.
+- Added theme persistence in `assets/js/main.js` using `localStorage`, with dark mode as the fallback when no explicit preference exists.
+- Added an inline pre-hydration theme bootstrap in each HTML entry point so a stored light preference applies before CSS paints.
+- Updated `assets/css/styles.css` and `assets/css/work-case-study.css` with light-theme tokens, rail toggle styling, and light-mode icon/logo adjustments.
+- Updated `README.md` to describe the new rail toggle and the manual theme behavior.
 
 ## Verification
-- Keyboard through the homepage and confirm the logo, left rail anchors, social links, CTA buttons, footer links, and `cols` toggle all show the subdued red focus ring plus outer glow.
-- Confirm those control-style elements also pick up the subtle red halo without shifting layout.
-- Keyboard through `/work`, `/work/resy-discovery/`, and `/work/sendmoi/` and confirm the same focus treatment appears there.
-- Confirm mouse clicks no longer leave the browser’s default purple focus ring on the logo.
-- In mobile Safari light and dark system appearance, confirm the site/browser chrome stays on the dark theme hints (`color-scheme: dark` and black `theme-color`) where Safari honors them.
+- `node --check assets/js/main.js`
+- `git diff --check`
+- Manual browser pass still needed:
+  - confirm first load stays dark even when the OS/browser is in light mode
+  - confirm the `light` toggle appears before `cols` in the left rail on home and work pages
+  - confirm toggling to light persists across navigation and refresh
+  - confirm browser chrome/theme-color flips between dark and light with the manual selection
+  - confirm the filtered rail logo/icons still read cleanly on the light background
 
 ## Open Items
-- Push `codex/focus-states` and open the PR for issue `#32`.
+- Run a visual browser QA pass, then push `codex/light-mode-toggle` and open the PR for issue `#36`.
 
 ## Resume Checklist
 1. `git branch --show-current`
 2. `git status --short`
 3. Review `README.md` and `HANDOFF.md`
-4. Run the local server and keyboard through home and work pages
-5. Confirm the focus ring/halo reads clearly on desktop and mobile layouts
-6. Push/open PR for `codex/focus-states`
+4. Run the local server and click through home and work pages in both dark and light theme states
+5. Confirm the manual theme toggle order, persistence, and browser chrome updates
+6. Push/open PR for `codex/light-mode-toggle`

--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ make dev PORT=8080
 
 `make dev-lan` is available as an alias of `make dev`.
 
+For worktree-based feature threads, use:
+
+```bash
+make dev-thread
+```
+
+That keeps `7777` available for the main checkout and starts worktree previews at `7778`, auto-cascading to `7779`, `7780`, and upward when other worktree previews are already running.
+
 ## Development workflow
 
 Before starting implementation work:
@@ -35,6 +43,7 @@ git branch --show-current
 - If you are on `main`, create or switch to a feature branch before editing files.
 - Do not use `main` as the active development branch.
 - Preferred workflow: use a dedicated `git worktree` per feature branch/thread.
+- For rendered site work in a worktree, start or reuse a preview there and surface the exact URL with the change.
 
 Example:
 
@@ -57,6 +66,14 @@ make dev-live
 ```
 
 This uses BrowserSync to serve the repo and reload when HTML/CSS/JS files change. It opens the same resolved `<this-mac>.local` URL as `make dev` instead of BrowserSync's default `localhost`.
+
+For live reload from a worktree thread, use:
+
+```bash
+make dev-live-thread
+```
+
+This follows the same `7778+` worktree port cascade as `make dev-thread`.
 
 Requirements:
 - Node.js with `npx` available (recommended: Node 20 via `nvm use 20`)
@@ -115,7 +132,7 @@ The deploy script stages a temporary copy of the managed site paths (`index.html
 - The SendMoi CTA routes to `/work/sendmoi/`, a standalone long-form article page.
 - The `Full Work Experience & Resume →` link on home now routes to `/work`.
 - `/work` now acts as a work overview page with a smaller home-style two-line title treatment (`Work Experience` in white, `& Resume` in red), a reserved resume block, and a separate case-study section with a left-aligned `Case Studies` heading and a 2-up grid for the current Resy and SendMoi writeups.
-- Child work pages now use the same desktop left rail treatment as home (spinning logo, left vertical rule, home nav icon, and `cols` toggle).
+- Child work pages now use the same desktop left rail treatment as home (spinning logo, left vertical rule, home/back nav icon set, `light` toggle, and `cols` toggle).
 - Work article pages (`/work/resy-discovery/`, `/work/sendmoi/`) now keep the home-style rail nav items (`Home`, `Work Experience`, `Resy`, `SendMoi`) with static active state per page (no scroll-driven switching on child pages).
 - On article pages, the `Work Experience` rail item now links to `/work`.
 - On article pages, the first rail item now uses a back icon (`icon-back-off/on/hover.svg`) instead of the home icon.
@@ -134,7 +151,7 @@ The deploy script stages a temporary copy of the managed site paths (`index.html
   - `Case Studies` column
 - Footer link styling is white with animated underline on hover/focus.
 - Footer social links are icon-based and reuse the same obfuscated email behavior (`data-email-link`) as the topper.
-- Interactive focus states across home and work pages now use a shared subdued red `:focus-visible` outline with a separate soft red outer glow on control-style elements like the spinning logo, rail nav items, social icons, cards, CTAs, and the `cols` toggle.
+- Interactive focus states across home and work pages now use a shared subdued red `:focus-visible` outline with a separate soft red outer glow on control-style elements like the spinning logo, rail nav items, social icons, cards, CTAs, the `light` toggle, and the `cols` toggle.
 
 ## Legacy removal
 
@@ -159,5 +176,6 @@ The deploy script stages a temporary copy of the managed site paths (`index.html
 - The mobile horizontal scrollers no longer force `pan-x` only, which reduces vertical scroll lock/jumping during touch interactions.
 - Homepage company-link hover underlines now only apply on hover-capable devices, avoiding sticky touch hover states on iPhone.
 - The mobile top inset and logo-to-heading spacing were tightened to better match the Figma mobile frame.
-- The site now declares a dark browser color scheme, and all home/work pages declare a black browser `theme-color`.
+- Home and work pages now default to dark mode even when the visitor’s OS prefers light, and the left rail includes a persistent `light` toggle for manually switching themes.
+- Browser theme hints (`color-scheme` and `theme-color`) now switch between dark and light to match the active manual theme selection.
 - CSS and JS assets use deploy-time cache-busting query params in the staged homepage HTML; if Safari looks stale locally, do a hard refresh.

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -3,16 +3,48 @@
   --bg: #000000;
   --fg: #ffffff;
   --accent: #ff453a;
+  --accent-hover: #ff6a60;
   --focus-ring: rgba(255, 69, 58, 0.75);
   --focus-shadow: rgba(255, 69, 58, 0.25);
   --line: #2e2e2e;
   --muted: #ebebf5;
+  --toggle-track-on: #2d2d33;
+  --toggle-track-off: #1f2025;
+  --toggle-knob-on: #f2f2f2;
+  --toggle-knob-off: #8e8f98;
+  --toggle-label: #8e8f98;
+  --grid-overlay-fill: rgba(255, 255, 255, 0.08);
+  --footer-meta: #8e8f98;
+  --footer-heading: #8e8f98;
+  --footer-link-underline: rgba(255, 255, 255, 0.92);
+  --logo-filter: none;
+  --nav-icon-filter: none;
+  --media-fg: #ffffff;
   --safe-top: env(safe-area-inset-top, 0px);
   --grid-cols: 12;
   --grid-col-width: 69px;
   --grid-gutter: 40px;
   --grid-width: 1268px;
   --display-optical-outdent: -0.03em;
+}
+
+:root[data-theme="light"] {
+  color-scheme: light;
+  --bg: #f5f1e8;
+  --fg: #121212;
+  --line: #d6d0c6;
+  --muted: #474a51;
+  --toggle-track-on: #1f2025;
+  --toggle-track-off: #d4cec2;
+  --toggle-knob-on: #f5f1e8;
+  --toggle-knob-off: #6f737a;
+  --toggle-label: #5f6268;
+  --grid-overlay-fill: rgba(18, 18, 18, 0.08);
+  --footer-meta: #5f6268;
+  --footer-heading: #5f6268;
+  --footer-link-underline: rgba(18, 18, 18, 0.88);
+  --logo-filter: brightness(0) saturate(100%);
+  --nav-icon-filter: brightness(0) saturate(100%);
 }
 
 @font-face {
@@ -97,7 +129,7 @@ a:visited {
 }
 
 a:focus-visible {
-  color: #ff6a60;
+  color: var(--accent-hover);
 }
 
 :where(
@@ -107,6 +139,7 @@ a:focus-visible {
   .social-links a,
   .site-footer-social a,
   .case-study-promo-cta,
+  .theme-toggle,
   .cols-toggle
 ):focus-visible {
   border-radius: 10px;
@@ -167,6 +200,8 @@ body.is-pulling-refresh .rail::after {
   will-change: transform;
   cursor: pointer;
   z-index: 25;
+  filter: var(--logo-filter);
+  transition: filter 0.22s ease;
 }
 
 .rail-nav {
@@ -188,6 +223,79 @@ body.is-pulling-refresh .rail::after {
   position: fixed;
   left: 0;
   top: calc(140px + var(--safe-top));
+}
+
+.theme-toggle {
+  width: 90px;
+  min-height: 92px;
+  border: 0;
+  border-top: 1px solid var(--line);
+  background: transparent;
+  color: var(--fg);
+  font: inherit;
+  font-size: 16px;
+  letter-spacing: -0.01em;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 14px 0 16px;
+  cursor: pointer;
+  transition: color 0.22s ease;
+}
+
+.theme-toggle-switch {
+  width: 40px;
+  height: 17.5px;
+  border-radius: 999px;
+  background: var(--toggle-track-on);
+  position: relative;
+  transition: background 0.22s ease;
+}
+
+.theme-toggle-switch::before {
+  content: "";
+  position: absolute;
+  top: 1.25px;
+  left: 1.25px;
+  width: 15px;
+  height: 15px;
+  border-radius: 50%;
+  background: var(--toggle-knob-on);
+  transform: translateX(22.5px);
+  transition: transform 0.26s cubic-bezier(0.2, 0.8, 0.2, 1), background 0.22s ease;
+}
+
+.theme-toggle-label {
+  line-height: 1;
+  text-transform: lowercase;
+  color: var(--toggle-label);
+}
+
+.theme-toggle.is-off {
+  color: var(--muted);
+}
+
+.theme-toggle.is-off .theme-toggle-switch {
+  background: var(--toggle-track-off);
+}
+
+.theme-toggle.is-off .theme-toggle-switch::before {
+  transform: translateX(0);
+  background: var(--toggle-knob-off);
+}
+
+.theme-toggle-state {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .cols-toggle {
@@ -214,7 +322,7 @@ body.is-pulling-refresh .rail::after {
   width: 40px;
   height: 17.5px;
   border-radius: 999px;
-  background: #2d2d33;
+  background: var(--toggle-track-on);
   position: relative;
   transition: background 0.22s ease;
 }
@@ -227,7 +335,7 @@ body.is-pulling-refresh .rail::after {
   width: 15px;
   height: 15px;
   border-radius: 50%;
-  background: #f2f2f2;
+  background: var(--toggle-knob-on);
   transform: translateX(22.5px);
   transition: transform 0.26s cubic-bezier(0.2, 0.8, 0.2, 1), background 0.22s ease;
 }
@@ -235,7 +343,7 @@ body.is-pulling-refresh .rail::after {
 .cols-toggle-label {
   line-height: 1;
   text-transform: lowercase;
-  color: #8e8f98;
+  color: var(--toggle-label);
 }
 
 .cols-toggle.is-off {
@@ -243,12 +351,12 @@ body.is-pulling-refresh .rail::after {
 }
 
 .cols-toggle.is-off .cols-toggle-switch {
-  background: #1f2025;
+  background: var(--toggle-track-off);
 }
 
 .cols-toggle.is-off .cols-toggle-switch::before {
   transform: translateX(0);
-  background: #8e8f98;
+  background: var(--toggle-knob-off);
 }
 
 .cols-toggle-state {
@@ -283,6 +391,12 @@ body.is-pulling-refresh .rail::after {
   object-fit: contain;
   opacity: 1;
   transition: opacity 0.18s ease;
+}
+
+.case-anchor .icon-off,
+.case-anchor .icon-on {
+  filter: var(--nav-icon-filter);
+  transition: opacity 0.18s ease, filter 0.22s ease;
 }
 
 .case-anchor-sendmoi img {
@@ -409,6 +523,8 @@ body.is-pulling-refresh .rail::after {
 
 .mobile-logo-mark {
   display: none;
+  filter: var(--logo-filter);
+  transition: filter 0.22s ease;
 }
 
 .mobile-page-dots {
@@ -496,7 +612,7 @@ body.is-pulling-refresh .rail::after {
 }
 
 .grid-overlay > span {
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--grid-overlay-fill);
   opacity: 1;
   transform: translateY(0) scaleY(1);
   transform-origin: top center;
@@ -739,7 +855,7 @@ body.grid-hidden .grid-overlay > span {
 
 @media (hover: hover) and (pointer: fine) {
   a:hover {
-    color: #ff6a60;
+    color: var(--accent-hover);
   }
 
   .topper-company-link:hover {
@@ -750,6 +866,11 @@ body.grid-hidden .grid-overlay > span {
   .experience-item .experience-company a:hover {
     color: inherit;
     border-bottom-color: rgba(255, 69, 58, 0.65);
+  }
+
+  .resume-link:hover {
+    color: var(--accent);
+    text-decoration-color: rgba(255, 69, 58, 0.65);
   }
 }
 
@@ -767,15 +888,27 @@ body.grid-hidden .grid-overlay > span {
 }
 
 .resume-link-wrap {
-  margin: 0;
+  margin: 34px 0 0;
   text-align: left;
 }
 
 .resume-link {
+  display: inline-block;
   color: var(--accent);
   font-size: 18px;
   font-weight: 700;
-  text-decoration: none;
+  text-decoration-line: underline;
+  text-decoration-color: transparent;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.22em;
+  line-height: 1.08;
+  padding-bottom: 0;
+  transition: text-decoration-color 0.18s ease, color 0.2s ease;
+}
+
+.resume-link:focus-visible {
+  color: var(--accent);
+  text-decoration-color: rgba(255, 69, 58, 0.65);
 }
 
 .resume-link.is-disabled {
@@ -843,7 +976,7 @@ body.grid-hidden .grid-overlay > span {
   gap: 20px;
   width: min(508px, calc(100% - 212px));
   margin-left: 106px;
-  color: var(--fg);
+  color: var(--media-fg);
 }
 
 .case-study-promo-logo {
@@ -862,7 +995,7 @@ body.grid-hidden .grid-overlay > span {
 
 .case-study-promo-eyebrow {
   margin: 0;
-  color: var(--fg);
+  color: var(--media-fg);
   font-size: 24px;
   line-height: 1.35;
   font-weight: 700;
@@ -870,7 +1003,7 @@ body.grid-hidden .grid-overlay > span {
 
 .case-study-promo h3 {
   margin: 0;
-  color: var(--fg);
+  color: var(--media-fg);
   font-size: 48px;
   line-height: 1;
   font-weight: 700;
@@ -955,14 +1088,14 @@ body.grid-hidden .grid-overlay > span {
 
 .site-footer-meta {
   margin: 24px 0 0;
-  color: #8e8f98;
+  color: var(--footer-meta);
   font-size: 16px;
   line-height: 1.35;
 }
 
 .site-footer-column h3 {
   margin: 0;
-  color: #8e8f98;
+  color: var(--footer-heading);
   font-size: 16px;
   line-height: 1.1;
   font-weight: 700;
@@ -1002,7 +1135,7 @@ body.grid-hidden .grid-overlay > span {
   bottom: -2px;
   width: 100%;
   height: 1px;
-  background: rgba(255, 255, 255, 0.92);
+  background: var(--footer-link-underline);
   transform: scaleX(0);
   transform-origin: left center;
   transition: transform 0.22s ease;
@@ -2537,6 +2670,7 @@ body.grid-hidden .grid-overlay > span {
   }
 
   .resume-link-wrap {
+    margin-top: 24px;
     text-align: left;
   }
 

--- a/assets/css/work-case-study.css
+++ b/assets/css/work-case-study.css
@@ -29,8 +29,24 @@
   --muted: #ebebf5;
   --line: #2e2e2e;
   --accent: #ff453a;
+  --accent-hover: #ff6a60;
   --focus-ring: rgba(255, 69, 58, 0.75);
   --focus-shadow: rgba(255, 69, 58, 0.25);
+  --toggle-track-on: #2d2d33;
+  --toggle-track-off: #1f2025;
+  --toggle-knob-on: #f2f2f2;
+  --toggle-knob-off: #8e8f98;
+  --toggle-label: #8e8f98;
+  --grid-overlay-fill: rgba(255, 255, 255, 0.08);
+  --work-card-bg: #0d0d0f;
+  --meta-label: rgba(235, 235, 245, 0.7);
+  --figure-caption: rgba(235, 235, 245, 0.74);
+  --footer-meta: #8e8f98;
+  --footer-heading: #8e8f98;
+  --footer-link-underline: rgba(255, 255, 255, 0.92);
+  --logo-filter: none;
+  --nav-icon-filter: none;
+  --media-fg: #ffffff;
   --grid-cols: 12;
   --grid-gutter: 40px;
   --safe-top: env(safe-area-inset-top, 0px);
@@ -50,6 +66,28 @@
   --work-logo-height-desktop: 44px;
   --work-logo-width-mobile: 50px;
   --work-logo-height-mobile: 22px;
+}
+
+:root[data-theme="light"] {
+  color-scheme: light;
+  --bg: #f5f1e8;
+  --fg: #121212;
+  --muted: #474a51;
+  --line: #d6d0c6;
+  --toggle-track-on: #1f2025;
+  --toggle-track-off: #d4cec2;
+  --toggle-knob-on: #f5f1e8;
+  --toggle-knob-off: #6f737a;
+  --toggle-label: #5f6268;
+  --grid-overlay-fill: rgba(18, 18, 18, 0.08);
+  --work-card-bg: #ece5db;
+  --meta-label: rgba(18, 18, 18, 0.64);
+  --figure-caption: rgba(18, 18, 18, 0.7);
+  --footer-meta: #5f6268;
+  --footer-heading: #5f6268;
+  --footer-link-underline: rgba(18, 18, 18, 0.88);
+  --logo-filter: brightness(0) saturate(100%);
+  --nav-icon-filter: brightness(0) saturate(100%);
 }
 
 * {
@@ -144,6 +182,8 @@ body.is-pulling-refresh .rail::after {
   will-change: transform;
   cursor: pointer;
   z-index: 25;
+  filter: var(--logo-filter);
+  transition: filter 0.22s ease;
 }
 
 .work-side-nav {
@@ -174,6 +214,12 @@ body.is-pulling-refresh .rail::after {
   object-fit: contain;
   opacity: 1;
   transition: opacity 0.18s ease;
+}
+
+.work-case-anchor .icon-off,
+.work-case-anchor .icon-on {
+  filter: var(--nav-icon-filter);
+  transition: opacity 0.18s ease, filter 0.22s ease;
 }
 
 .work-case-anchor-sendmoi img {
@@ -213,6 +259,79 @@ body.is-pulling-refresh .rail::after {
   opacity: 1;
 }
 
+.theme-toggle {
+  width: 90px;
+  min-height: 92px;
+  border: 0;
+  border-top: 1px solid var(--line);
+  background: transparent;
+  color: var(--fg);
+  font: inherit;
+  font-size: 16px;
+  letter-spacing: -0.01em;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 14px 0 16px;
+  cursor: pointer;
+  transition: color 0.22s ease;
+}
+
+.theme-toggle-switch {
+  width: 40px;
+  height: 17.5px;
+  border-radius: 999px;
+  background: var(--toggle-track-on);
+  position: relative;
+  transition: background 0.22s ease;
+}
+
+.theme-toggle-switch::before {
+  content: "";
+  position: absolute;
+  top: 1.25px;
+  left: 1.25px;
+  width: 15px;
+  height: 15px;
+  border-radius: 50%;
+  background: var(--toggle-knob-on);
+  transform: translateX(22.5px);
+  transition: transform 0.26s cubic-bezier(0.2, 0.8, 0.2, 1), background 0.22s ease;
+}
+
+.theme-toggle-label {
+  line-height: 1;
+  text-transform: lowercase;
+  color: var(--toggle-label);
+}
+
+.theme-toggle.is-off {
+  color: var(--muted);
+}
+
+.theme-toggle.is-off .theme-toggle-switch {
+  background: var(--toggle-track-off);
+}
+
+.theme-toggle.is-off .theme-toggle-switch::before {
+  transform: translateX(0);
+  background: var(--toggle-knob-off);
+}
+
+.theme-toggle-state {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .cols-toggle {
   width: 90px;
   min-height: 92px;
@@ -237,7 +356,7 @@ body.is-pulling-refresh .rail::after {
   width: 40px;
   height: 17.5px;
   border-radius: 999px;
-  background: #2d2d33;
+  background: var(--toggle-track-on);
   position: relative;
   transition: background 0.22s ease;
 }
@@ -250,7 +369,7 @@ body.is-pulling-refresh .rail::after {
   width: 15px;
   height: 15px;
   border-radius: 50%;
-  background: #f2f2f2;
+  background: var(--toggle-knob-on);
   transform: translateX(22.5px);
   transition: transform 0.26s cubic-bezier(0.2, 0.8, 0.2, 1), background 0.22s ease;
 }
@@ -258,7 +377,7 @@ body.is-pulling-refresh .rail::after {
 .cols-toggle-label {
   line-height: 1;
   text-transform: lowercase;
-  color: #8e8f98;
+  color: var(--toggle-label);
 }
 
 .cols-toggle.is-off {
@@ -266,12 +385,12 @@ body.is-pulling-refresh .rail::after {
 }
 
 .cols-toggle.is-off .cols-toggle-switch {
-  background: #1f2025;
+  background: var(--toggle-track-off);
 }
 
 .cols-toggle.is-off .cols-toggle-switch::before {
   transform: translateX(0);
-  background: #8e8f98;
+  background: var(--toggle-knob-off);
 }
 
 .cols-toggle-state {
@@ -306,7 +425,7 @@ a {
 
 a:hover,
 a:focus-visible {
-  color: #ff6a60;
+  color: var(--accent-hover);
 }
 
 :where(
@@ -315,6 +434,7 @@ a:focus-visible {
   .work-case-anchor,
   .site-footer-social a,
   .work-index-card,
+  .theme-toggle,
   .cols-toggle
 ):focus-visible {
   border-radius: 10px;
@@ -381,7 +501,7 @@ a:focus-visible {
 }
 
 .work-grid-overlay > span {
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--grid-overlay-fill);
   opacity: 1;
   transform: translateY(0) scaleY(1);
   transform-origin: top center;
@@ -424,6 +544,7 @@ body.grid-hidden .work-grid-overlay > span {
   width: min(520px, calc(100% - 60px));
   margin-left: 30px;
   padding: 42px 0;
+  color: var(--media-fg);
 }
 
 .work-article-logo {
@@ -470,7 +591,7 @@ body.grid-hidden .work-grid-overlay > span {
   margin: 0 0 4px;
   font-size: 13px;
   line-height: 1.35;
-  color: rgba(235, 235, 245, 0.7);
+  color: var(--meta-label);
 }
 
 .work-article-meta-value {
@@ -572,7 +693,7 @@ body.grid-hidden .work-grid-overlay > span {
 .work-index-card-media {
   margin: 0;
   overflow: hidden;
-  background: #0d0d0f;
+  background: var(--work-card-bg);
   aspect-ratio: 16 / 10;
 }
 
@@ -592,7 +713,7 @@ body.grid-hidden .work-grid-overlay > span {
   margin: 0;
   font-size: 15px;
   line-height: 1.35;
-  color: rgba(235, 235, 245, 0.72);
+  color: var(--meta-label);
 }
 
 .work-index-card h4 {
@@ -626,7 +747,7 @@ body.grid-hidden .work-grid-overlay > span {
 
 .work-index-card:hover .work-index-card-cta,
 .work-index-card:focus-visible .work-index-card-cta {
-  color: #ff6a60;
+  color: var(--accent-hover);
 }
 
 .work-article-section + .work-article-section {
@@ -689,7 +810,7 @@ body.grid-hidden .work-grid-overlay > span {
   margin-top: 8px;
   font-size: 14px;
   line-height: 1.35;
-  color: rgba(235, 235, 245, 0.74);
+  color: var(--figure-caption);
 }
 
 .site-footer {
@@ -741,14 +862,14 @@ body.grid-hidden .work-grid-overlay > span {
 
 .site-footer-meta {
   margin: 18px 0 0;
-  color: #8e8f98;
+  color: var(--footer-meta);
   font-size: 16px;
   line-height: 1.35;
 }
 
 .site-footer-column h3 {
   margin: 0;
-  color: #8e8f98;
+  color: var(--footer-heading);
   font-size: 16px;
   line-height: 1.1;
   font-weight: 700;
@@ -788,7 +909,7 @@ body.grid-hidden .work-grid-overlay > span {
   bottom: -2px;
   width: 100%;
   height: 1px;
-  background: rgba(255, 255, 255, 0.92);
+  background: var(--footer-link-underline);
   transform: scaleX(0);
   transform-origin: left center;
   transition: transform 0.22s ease;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,8 +1,14 @@
 const caseNav = document.querySelector(".case-nav");
 const logoMarks = Array.from(document.querySelectorAll(".logo-mark, .mobile-logo-mark"));
+const themeToggles = Array.from(document.querySelectorAll(".theme-toggle"));
 const colsToggles = Array.from(document.querySelectorAll(".cols-toggle"));
 const emailLinks = Array.from(document.querySelectorAll("[data-email-link]"));
+const themeColorMeta = document.querySelector('meta[name="theme-color"]');
+const colorSchemeMeta = document.querySelector('meta[name="color-scheme"]');
+const THEME_STORAGE_KEY = "nieder.theme";
 const COLS_TOGGLE_STORAGE_KEY = "nieder.cols-grid-visible";
+const LIGHT_THEME_COLOR = "#f5f1e8";
+const DARK_THEME_COLOR = "#000000";
 const scrollToPageTop = () => {
   window.scrollTo({ top: 0, behavior: "smooth" });
   if (window.location.hash) {
@@ -62,6 +68,58 @@ if (emailLinks.length > 0) {
     }
     promo.style.setProperty("--case-study-promo-focus-desktop", desktopFocus);
     promo.style.setProperty("--case-study-promo-focus-mobile", mobileFocus);
+  });
+}
+
+if (themeToggles.length > 0) {
+  const applyTheme = (theme, persist = true) => {
+    const nextTheme = theme === "light" ? "light" : "dark";
+    const isLight = nextTheme === "light";
+    document.documentElement.dataset.theme = nextTheme;
+    document.documentElement.style.colorScheme = nextTheme;
+
+    if (themeColorMeta) {
+      themeColorMeta.setAttribute("content", isLight ? LIGHT_THEME_COLOR : DARK_THEME_COLOR);
+    }
+    if (colorSchemeMeta) {
+      colorSchemeMeta.setAttribute("content", nextTheme);
+    }
+
+    themeToggles.forEach((toggle) => {
+      toggle.classList.toggle("is-on", isLight);
+      toggle.classList.toggle("is-off", !isLight);
+      toggle.setAttribute("aria-pressed", String(isLight));
+      toggle.setAttribute(
+        "aria-label",
+        isLight ? "Switch to dark mode" : "Switch to light mode"
+      );
+      const state = toggle.querySelector(".theme-toggle-state");
+      if (state) state.textContent = isLight ? "On" : "Off";
+    });
+
+    if (persist) {
+      try {
+        window.localStorage.setItem(THEME_STORAGE_KEY, nextTheme);
+      } catch (error) {
+        // Ignore storage access failures (privacy mode, browser restrictions).
+      }
+    }
+  };
+
+  let theme = "dark";
+  try {
+    const storedTheme = window.localStorage.getItem(THEME_STORAGE_KEY);
+    if (storedTheme === "light") theme = "light";
+  } catch (error) {
+    // Ignore storage access failures and keep the dark default.
+  }
+
+  applyTheme(theme, false);
+  themeToggles.forEach((toggle) => {
+    toggle.addEventListener("click", () => {
+      const isLight = document.documentElement.dataset.theme === "light";
+      applyTheme(isLight ? "dark" : "light");
+    });
   });
 }
 

--- a/index.html
+++ b/index.html
@@ -37,7 +37,23 @@
     <meta name="twitter:url" content="https://nieder.me/2026/" />
     <meta name="twitter:image" content="https://nieder.me/2026/assets/images/share/og-image-1200x630.png" />
     <meta name="twitter:image:alt" content="Preview of John Niedermeyer's product design portfolio." />
-    <link rel="stylesheet" href="assets/css/styles.css?v=20260311-001" />
+    <script>
+      (() => {
+        try {
+          const storedTheme = window.localStorage.getItem("nieder.theme");
+          if (storedTheme !== "light") return;
+          document.documentElement.dataset.theme = "light";
+          document.documentElement.style.colorScheme = "light";
+          const themeColorMeta = document.querySelector('meta[name="theme-color"]');
+          const colorSchemeMeta = document.querySelector('meta[name="color-scheme"]');
+          if (themeColorMeta) themeColorMeta.setAttribute("content", "#f5f1e8");
+          if (colorSchemeMeta) colorSchemeMeta.setAttribute("content", "light");
+        } catch (error) {
+          // Ignore storage access failures and keep the dark default.
+        }
+      })();
+    </script>
+    <link rel="stylesheet" href="assets/css/styles.css?v=20260312-008" />
   </head>
   <body id="top">
     <div class="page">
@@ -66,6 +82,11 @@
           <img class="icon-on" src="assets/icons/side-nav/icon-work-sendmoi-on.svg" alt="" />
           <img class="icon-hover" src="assets/icons/side-nav/icon-work-sendmoi-hover.svg" alt="" />
         </a>
+        <button class="theme-toggle is-off" type="button" aria-pressed="false" aria-label="Switch to light mode">
+          <span class="theme-toggle-switch" aria-hidden="true"></span>
+          <span class="theme-toggle-label">light</span>
+          <span class="theme-toggle-state" aria-live="polite">Off</span>
+        </button>
         <button class="cols-toggle is-on" type="button" aria-pressed="true" aria-label="Hide column grid">
           <span class="cols-toggle-switch" aria-hidden="true"></span>
           <span class="cols-toggle-label">cols</span>
@@ -126,6 +147,9 @@
           <div class="experience-grid">
             <header class="experience-heading">
               <h3>Work Experience</h3>
+              <p class="resume-link-wrap">
+                <a class="resume-link" href="/work">Full Work<br />Experience<br />&amp; Resume →</a>
+              </p>
             </header>
 
             <div class="experience-columns-carousel">
@@ -192,11 +216,6 @@
                   <p class="experience-date">Nov. 2006 - July 2007</p>
                   <p>Key clients: Microsoft, General Electric, Autodesk, PTC.</p>
                 </article>
-
-                <div class="rule short"></div>
-                <p class="resume-link-wrap">
-                  <a class="resume-link" href="/work">Full Work Experience &amp; Resume →</a>
-                </p>
               </div>
             </div>
           </div>
@@ -237,7 +256,7 @@
               <img class="case-study-promo-logo" src="assets/images/home/case-study-promos/logo-sendmoi-promo.svg" alt="SendMoi" />
               <div class="case-study-promo-inner">
                 <p class="case-study-promo-eyebrow">SendMoi for iOS &amp; MacOS</p>
-                <h3 id="case-study-promo-sendmoi-title">Designed &amp; built with a little help from AI coding tools.</h3>
+                <h3 id="case-study-promo-sendmoi-title">Designed &amp; Built With a Little Help From AI Coding Tools</h3>
               </div>
               <a class="case-study-promo-cta" href="work/sendmoi/">View Case Study</a>
             </div>
@@ -295,6 +314,6 @@
 
       </main>
     </div>
-    <script src="assets/js/main.js?v=20260310-030"></script>
+    <script src="assets/js/main.js?v=20260312-008"></script>
   </body>
 </html>

--- a/work/index.html
+++ b/work/index.html
@@ -10,7 +10,23 @@
       name="description"
       content="Work overview page with room for a fuller resume and current case studies across Resy and SendMoi."
     />
-    <link rel="stylesheet" href="../assets/css/work-case-study.css?v=20260312-007" />
+    <script>
+      (() => {
+        try {
+          const storedTheme = window.localStorage.getItem("nieder.theme");
+          if (storedTheme !== "light") return;
+          document.documentElement.dataset.theme = "light";
+          document.documentElement.style.colorScheme = "light";
+          const themeColorMeta = document.querySelector('meta[name="theme-color"]');
+          const colorSchemeMeta = document.querySelector('meta[name="color-scheme"]');
+          if (themeColorMeta) themeColorMeta.setAttribute("content", "#f5f1e8");
+          if (colorSchemeMeta) colorSchemeMeta.setAttribute("content", "light");
+        } catch (error) {
+          // Ignore storage access failures and keep the dark default.
+        }
+      })();
+    </script>
+    <link rel="stylesheet" href="../assets/css/work-case-study.css?v=20260312-008" />
   </head>
   <body id="top" class="work-index-page">
     <div class="work-page">
@@ -39,6 +55,11 @@
           <img class="icon-on" src="../assets/icons/side-nav/icon-work-sendmoi-on.svg" alt="" />
           <img class="icon-hover" src="../assets/icons/side-nav/icon-work-sendmoi-hover.svg" alt="" />
         </a>
+        <button class="theme-toggle is-off" type="button" aria-pressed="false" aria-label="Switch to light mode">
+          <span class="theme-toggle-switch" aria-hidden="true"></span>
+          <span class="theme-toggle-label">light</span>
+          <span class="theme-toggle-state" aria-live="polite">Off</span>
+        </button>
         <button class="cols-toggle is-on" type="button" aria-pressed="true" aria-label="Hide column grid">
           <span class="cols-toggle-switch" aria-hidden="true"></span>
           <span class="cols-toggle-label">cols</span>
@@ -98,7 +119,7 @@
                 </figure>
                 <div class="work-index-card-copy">
                   <p class="work-index-card-eyebrow">SendMoi for iOS &amp; MacOS</p>
-                  <h4 id="work-index-sendmoi-title">Designed &amp; built with a little help from AI coding tools.</h4>
+                  <h4 id="work-index-sendmoi-title">Designed &amp; Built With a Little Help From AI Coding Tools</h4>
                   <p class="work-index-card-summary">
                     End-to-end product, brand, and implementation work for a send-to-self utility.
                   </p>
@@ -159,6 +180,6 @@
         </footer>
       </main>
     </div>
-    <script src="../assets/js/main.js?v=20260310-020"></script>
+    <script src="../assets/js/main.js?v=20260312-008"></script>
   </body>
 </html>

--- a/work/resy-discovery/index.html
+++ b/work/resy-discovery/index.html
@@ -10,7 +10,23 @@
       name="description"
       content="Standalone long-form case study on evolving in-app restaurant discovery for the Resy consumer app."
     />
-    <link rel="stylesheet" href="../../assets/css/work-case-study.css?v=20260312-007" />
+    <script>
+      (() => {
+        try {
+          const storedTheme = window.localStorage.getItem("nieder.theme");
+          if (storedTheme !== "light") return;
+          document.documentElement.dataset.theme = "light";
+          document.documentElement.style.colorScheme = "light";
+          const themeColorMeta = document.querySelector('meta[name="theme-color"]');
+          const colorSchemeMeta = document.querySelector('meta[name="color-scheme"]');
+          if (themeColorMeta) themeColorMeta.setAttribute("content", "#f5f1e8");
+          if (colorSchemeMeta) colorSchemeMeta.setAttribute("content", "light");
+        } catch (error) {
+          // Ignore storage access failures and keep the dark default.
+        }
+      })();
+    </script>
+    <link rel="stylesheet" href="../../assets/css/work-case-study.css?v=20260312-008" />
   </head>
   <body id="top">
     <div class="work-page">
@@ -39,6 +55,11 @@
           <img class="icon-on" src="../../assets/icons/side-nav/icon-work-sendmoi-on.svg" alt="" />
           <img class="icon-hover" src="../../assets/icons/side-nav/icon-work-sendmoi-hover.svg" alt="" />
         </a>
+        <button class="theme-toggle is-off" type="button" aria-pressed="false" aria-label="Switch to light mode">
+          <span class="theme-toggle-switch" aria-hidden="true"></span>
+          <span class="theme-toggle-label">light</span>
+          <span class="theme-toggle-state" aria-live="polite">Off</span>
+        </button>
         <button class="cols-toggle is-on" type="button" aria-pressed="true" aria-label="Hide column grid">
           <span class="cols-toggle-switch" aria-hidden="true"></span>
           <span class="cols-toggle-label">cols</span>
@@ -237,6 +258,6 @@
         </footer>
       </main>
     </div>
-    <script src="../../assets/js/main.js?v=20260310-020"></script>
+    <script src="../../assets/js/main.js?v=20260312-008"></script>
   </body>
 </html>

--- a/work/sendmoi/index.html
+++ b/work/sendmoi/index.html
@@ -10,7 +10,23 @@
       name="description"
       content="Standalone long-form case study on designing and building SendMoi, a durable send-to-self utility across Apple platforms."
     />
-    <link rel="stylesheet" href="../../assets/css/work-case-study.css?v=20260312-007" />
+    <script>
+      (() => {
+        try {
+          const storedTheme = window.localStorage.getItem("nieder.theme");
+          if (storedTheme !== "light") return;
+          document.documentElement.dataset.theme = "light";
+          document.documentElement.style.colorScheme = "light";
+          const themeColorMeta = document.querySelector('meta[name="theme-color"]');
+          const colorSchemeMeta = document.querySelector('meta[name="color-scheme"]');
+          if (themeColorMeta) themeColorMeta.setAttribute("content", "#f5f1e8");
+          if (colorSchemeMeta) colorSchemeMeta.setAttribute("content", "light");
+        } catch (error) {
+          // Ignore storage access failures and keep the dark default.
+        }
+      })();
+    </script>
+    <link rel="stylesheet" href="../../assets/css/work-case-study.css?v=20260312-008" />
   </head>
   <body id="top" class="work-theme-sendmoi">
     <div class="work-page">
@@ -39,6 +55,11 @@
           <img class="icon-on" src="../../assets/icons/side-nav/icon-work-sendmoi-on.svg" alt="" />
           <img class="icon-hover" src="../../assets/icons/side-nav/icon-work-sendmoi-hover.svg" alt="" />
         </a>
+        <button class="theme-toggle is-off" type="button" aria-pressed="false" aria-label="Switch to light mode">
+          <span class="theme-toggle-switch" aria-hidden="true"></span>
+          <span class="theme-toggle-label">light</span>
+          <span class="theme-toggle-state" aria-live="polite">Off</span>
+        </button>
         <button class="cols-toggle is-on" type="button" aria-pressed="true" aria-label="Hide column grid">
           <span class="cols-toggle-switch" aria-hidden="true"></span>
           <span class="cols-toggle-label">cols</span>
@@ -233,6 +254,6 @@
         </footer>
       </main>
     </div>
-    <script src="../../assets/js/main.js?v=20260310-020"></script>
+    <script src="../../assets/js/main.js?v=20260312-008"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add a manual `light` toggle to the left rail before the existing `cols` switch on home and work pages
- keep dark mode as the default regardless of system appearance while persisting a manual light selection
- update browser theme hints plus README/HANDOFF notes to match the new theme behavior

## Verification
- `node --check assets/js/main.js`
- `git diff --check`

Closes #36