### PR TITLE
Add worktree preview workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@
 - If you are on `main`, create or switch to a feature branch before making changes.
 - Do not treat `main` as a working branch for active development, unless told explicitly to.
 - Default workflow for non-trivial work: create a dedicated `git worktree` for each active feature branch/thread so multiple branches can stay in progress at once. For trivial one-off changes, a normal branch in the main checkout is fine.
+- For rendered site work in a worktree, start or reuse a preview server from that worktree when needed so in-flight edits can be reviewed there.
 - Do not push directly to `main`; all work happens on a task branch, unless told explicitly to.
 - Work from `main` on short-lived branches named `codex/*`.
 - Start from latest `main`:
@@ -16,6 +17,10 @@
   - `git checkout -b codex/<short-slug>`
 - For concurrent work, use separate branches and prefer separate worktrees:
   - `git worktree add ../<repo-name>-<short-slug> -b codex/<short-slug> main`
+- Port convention for previews:
+  - keep `7777` as the default root-checkout preview port
+  - use `make dev-thread` or `make dev-live-thread` inside worktrees; those start at `7778` and auto-cascade to `7779`, `7780`, and upward as needed
+- When you edit HTML, CSS, JS, or other rendered site files and a preview server is running for that thread, include the exact preview URL in your response.
 - Keep scope tight: branch changes should stay focused on the linked issue.
 
 ### 2) Implement And Commit

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,36 +1,31 @@
 # Handoff
 
 ## Branch
-- `codex/light-mode-toggle`
+- `codex/worktree-preview-links`
 
 ## Current Focus
-- Ship the manual light-mode toggle on this branch via PR for issue `#36`.
+- Ship the worktree preview workflow update on this branch via PR for issue `#38`.
 
 ## What Changed
-- Opened GitHub issue `#36` to track a manual light-mode toggle with a hard dark default.
-- Added a new `light` rail toggle to the homepage, `/work`, `/work/resy-discovery/`, and `/work/sendmoi/`, positioned directly above the existing `cols` toggle.
-- Added theme persistence in `assets/js/main.js` using `localStorage`, with dark mode as the fallback when no explicit preference exists.
-- Added an inline pre-hydration theme bootstrap in each HTML entry point so a stored light preference applies before CSS paints.
-- Updated `assets/css/styles.css` and `assets/css/work-case-study.css` with light-theme tokens, rail toggle styling, and light-mode icon/logo adjustments.
-- Updated `README.md` to describe the new rail toggle and the manual theme behavior.
+- Opened GitHub issue `#38` to track a predictable preview workflow for concurrent worktree threads.
+- Added `make dev-thread` and `make dev-live-thread` in `Makefile`.
+- Reserved `7777` as the default root-checkout preview port and documented the `7778`, `7779`, `7780`, and upward cascade for worktree previews.
+- Updated `AGENTS.md` so rendered work in a worktree should start or reuse a preview when needed and include the exact preview URL in responses.
+- Updated `README.md` with the new worktree preview commands and the expectation to surface preview URLs for rendered changes.
 
 ## Verification
-- `node --check assets/js/main.js`
+- `make dev-thread`
 - `git diff --check`
-- Manual browser pass still needed:
-  - confirm first load stays dark even when the OS/browser is in light mode
-  - confirm the `light` toggle appears before `cols` in the left rail on home and work pages
-  - confirm toggling to light persists across navigation and refresh
-  - confirm browser chrome/theme-color flips between dark and light with the manual selection
-  - confirm the filtered rail logo/icons still read cleanly on the light background
+- Confirmed `make dev-thread` starts from `7778` and prints both the `.local` and LAN preview URLs.
+- Dry-run checked `make dev-live-thread` to confirm it also seeds from `7778`.
 
 ## Open Items
-- Run a visual browser QA pass, then push `codex/light-mode-toggle` and open the PR for issue `#36`.
+- Push `codex/worktree-preview-links` and open the PR for issue `#38`.
 
 ## Resume Checklist
 1. `git branch --show-current`
 2. `git status --short`
 3. Review `README.md` and `HANDOFF.md`
-4. Run the local server and click through home and work pages in both dark and light theme states
-5. Confirm the manual theme toggle order, persistence, and browser chrome updates
-6. Push/open PR for `codex/light-mode-toggle`
+4. Run `make dev-thread` or `make dev-live-thread`
+5. Confirm the preview URL uses the expected `7778+` worktree port range
+6. Push/open PR for `codex/worktree-preview-links`

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
-.PHONY: dev dev-lan dev-local dev-live site-url site-url-stage site-url-prod issue-create
+.PHONY: dev dev-lan dev-local dev-live dev-thread dev-live-thread site-url site-url-stage site-url-prod issue-create
 
 PORT ?= 7777
+THREAD_BASE_PORT ?= 7778
 BIND ?= 0.0.0.0
 LOCAL_HOST ?= localhost
 PORT_AUTO ?= 1
@@ -75,6 +76,9 @@ dev:
 	python3 -m http.server $$PORT_TO_USE --bind $(BIND)
 
 dev-lan: dev
+
+dev-thread: PORT := $(THREAD_BASE_PORT)
+dev-thread: dev
 
 dev-local:
 	@PORT_TO_USE="$(PORT)"; \
@@ -193,6 +197,9 @@ dev-live:
 	echo "(Ctrl+C to stop)"; \
 	(sleep 0.8; open "http://$$LOCAL_URL_HOST:$$PORT_TO_USE/") >/dev/null 2>&1 & \
 	npx browser-sync start --server . --files 'index.html,sendmoi/**/*.html,assets/css/**/*.css,assets/js/**/*.js' --host $(BIND) --port $$PORT_TO_USE --no-open
+
+dev-live-thread: PORT := $(THREAD_BASE_PORT)
+dev-live-thread: dev-live
 
 issue-create:
 	@if [ -z "$(ISSUE_TITLE)" ]; then \


### PR DESCRIPTION
## Summary
- add `make dev-thread` and `make dev-live-thread` for worktree previews starting at `7778`
- document the `7777` root-checkout port and `7778+` worktree port cascade
- update the handoff notes to reflect the new branch and issue

## Verification
- `make dev-thread`
- `make -n dev-live-thread | sed -n '1,20p'`
- `git diff --check`

Closes #38
