### PR TITLE
Clarify AGENTS.md worktree cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@
   - `git branch -d codex/<short-slug>` (if this fails after squash merge, use `git branch -D codex/<short-slug>`)
   - `git push origin --delete codex/<short-slug>` (if remote branch exists)
 - Clean up parallel workspace metadata when used:
+  - `git worktree remove ../<repo-name>-<short-slug>` (if you created a dedicated worktree for the branch)
   - `git worktree prune`
 
 ## GitHub Issues Workflow


### PR DESCRIPTION
## Summary
- add the missing `git worktree remove` step to the post-merge cleanup flow in `AGENTS.md`
- keep the cleanup guidance aligned with how worktrees are actually removed, not just pruned
- note that current `main` already uses a generic worktree naming example, so this PR addresses the remaining workflow gap from issue review

## Testing
- `git diff --check`

Closes #51