### PR TITLE
Fix compact desktop homepage and work breakpoints

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,38 +1,38 @@
 # Handoff
 
 ## Branch
-- `codex/colophon-blueprint`
+- `codex/fix-work-breakpoint`
 
 ## Current Focus
-- Finalize and land homepage colophon refinements for issue `#53`, including the simplified text layout, restored hero divider, and the alternate About portrait preview.
+- Land the compact desktop breakpoint fixes for homepage and `/work` under issue `#55`, covering sticky rail behavior, denser work-summary layout, and a grid-aligned About section.
 
 ## Tracking
-- GitHub issue `#53` tracks the homepage colophon refinement work.
+- GitHub issue `#55` tracks the compact desktop breakpoint fixes.
 
 ## What Changed
-- Removed the old split-word colophon treatment and simplified it to a smaller dashed outline heading.
-- Reworked the colophon section into a cleaner text-based layout with a left intro block and two-column note copy on desktop.
-- Tightened desktop spacing and breakpoint behavior to give the colophon more regular vertical rhythm.
-- Restored the missing top horizontal divider in the homepage hero to match the Figma desktop frame more closely.
-- Swapped the About portrait to `assets/images/home/about/portrait_3_4_hp5_2400h.png`, keeping the previous portrait asset in the repo.
+- Added a compact desktop breakpoint on the homepage for widths between `960px` and `1500px`.
+- Kept the homepage left rail visible and sticky through that breakpoint by aligning the JS lock threshold with the desktop CSS breakpoint.
+- Reflowed homepage `Work Experience` into a denser two-column layout before the smaller-screen collapse.
+- Reworked the homepage `About` section so the portrait sits on the shared column grid, stays top-aligned, and the copy uses wider two-column text.
+- Tightened `/work` and related rail positioning behavior so the side nav stays within the viewport at the same breakpoint range.
 
 ## Verification
 - `git diff --check`
-- Local preview running at `http://Niederbook-Air-M4.local:7779/`
-- Manual browser review against the local homepage preview during iteration
+- Local preview running at `http://Niederbook-Air-M4.local:7777/`
+- Manual browser review against the homepage and `/work` preview with the column grid enabled at the target breakpoint
 
 ## Open Items
 - Rebase this branch onto `origin/main`.
-- Push `codex/colophon-blueprint`.
-- Open the PR with `Closes #53`.
+- Push `codex/fix-work-breakpoint`.
+- Open the PR with `Closes #55`.
 
 ## Resume Checklist
 1. `git branch --show-current`
 2. `git status --short --branch`
-3. Open `http://Niederbook-Air-M4.local:7779/` and review the homepage hero, About section, and colophon
+3. Open `http://Niederbook-Air-M4.local:7777/` and review the homepage `Work Experience`, `About`, and `/work` sections at the compact desktop breakpoint
 4. Review `README.md` and `HANDOFF.md`
 5. Run `git diff --check`
 6. `git fetch origin`
 7. `git rebase origin/main`
-8. `git push -u origin codex/colophon-blueprint`
-9. Open the PR with `Closes #53`
+8. `git push -u origin codex/fix-work-breakpoint`
+9. Open the PR with `Closes #55`

--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ The deploy script stages a temporary copy of the managed site paths (`index.html
 - On article pages, the first rail item now uses a back icon (`icon-back-off/on/hover.svg`) instead of the home icon.
 - Promo cards use a `50px` corner radius and `50px` vertical spacing between cards.
 - Desktop rail nav on home now includes direct anchors for `Work Experience`, `Resy`, `SendMoi`, Somm AI, and `About`, with the Somm AI slot temporarily reusing the Resy `R` icon assets.
+- Viewports between `960px` and `1500px` now use a compact desktop treatment: the homepage rail remains sticky and on-screen, `Work Experience` reflows into a denser two-column layout, and the `About` section keeps its portrait on the shared grid while widening the two-column copy.
+- At the same compact desktop range, `/work` keeps the side rail within the viewport and tightens the resume layout before the existing sub-`1100px` stacked layout takes over.
 
 ## Homepage footer
 

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -258,7 +258,7 @@ body.is-pulling-refresh .rail::after {
 .rail-nav {
   position: fixed;
   left: 31px;
-  top: 717px;
+  top: clamp(calc(140px + var(--safe-top)), calc(100vh - 664px), 717px);
   width: 26px;
 }
 
@@ -1149,6 +1149,7 @@ body.grid-hidden .grid-overlay > span {
   height: auto;
   aspect-ratio: 2 / 3;
   object-fit: cover;
+  object-position: center top;
 }
 
 .about-home-copy {
@@ -1994,12 +1995,97 @@ body.grid-hidden .grid-overlay > span {
     margin-right: 40px;
   }
 
+  .rail-nav {
+    top: clamp(calc(140px + var(--safe-top)), calc(100vh - 664px), 560px);
+  }
+
   .social-links {
     margin-top: 92px;
   }
 
   .job-header {
     margin-top: 190px;
+  }
+
+  .work-experience {
+    margin-top: 156px;
+  }
+
+  .experience-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    column-gap: 32px;
+    row-gap: 20px;
+  }
+
+  .experience-heading {
+    grid-column: 1 / -1;
+  }
+
+  .experience-heading h3 {
+    font-size: clamp(42px, 4vw, 48px);
+  }
+
+  .resume-link-wrap {
+    margin-top: 24px;
+  }
+
+  .experience-columns-carousel {
+    display: grid;
+    grid-column: 1 / -1;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 32px;
+  }
+
+  .experience-column {
+    gap: 28px;
+  }
+
+  .experience-column:first-of-type,
+  .experience-column:last-of-type {
+    grid-column: auto;
+  }
+
+  .experience-item h4,
+  .experience-item .experience-company {
+    font-size: 17px;
+  }
+
+  .experience-item p {
+    font-size: 15px;
+  }
+
+  .experience-item-current p {
+    font-size: 17px;
+  }
+
+  .about-home-grid {
+    grid-template-columns: repeat(var(--grid-cols), minmax(0, 1fr));
+    column-gap: var(--grid-gutter);
+    align-items: start;
+  }
+
+  .about-home-portrait {
+    grid-column: 1 / span 3;
+    align-self: start;
+    max-width: none;
+  }
+
+  .about-home-copy {
+    grid-column: 5 / span 8;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 20px 32px;
+    max-width: none;
+  }
+
+  .about-home-copy .about-home-lead {
+    grid-column: 1 / -1;
+    max-width: 13ch;
+    font-size: clamp(26px, 2.3vw, 30px);
+  }
+
+  .about-home-copy p {
+    font-size: 18px;
+    line-height: 1.45;
   }
 }
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -208,7 +208,7 @@ if (caseNav) {
       caseNav.dataset.lockStartComputed || caseNav.dataset.lockStart || 1049
     );
 
-    if (window.innerWidth <= 1100) {
+    if (window.innerWidth <= 959) {
       caseNav.classList.remove("is-locked");
       return;
     }


### PR DESCRIPTION
## Summary
- add a compact desktop breakpoint for the homepage so the rail stays sticky, Work Experience reflows more cleanly, and About stays aligned to the shared grid
- keep the homepage rail lock JS active through the same breakpoint range as the desktop CSS
- tighten the /work compact desktop layout and refresh README/HANDOFF for the current branch state

## Testing
- `git diff --check`
- manual browser review at `http://Niederbook-Air-M4.local:7777/` with the column grid enabled on homepage and `/work`

Closes #55