### PR TITLE
feat: add shared link analytics attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,5 +179,5 @@ This helper requires the GitHub CLI (`gh`) to be installed and authenticated.
 
 - The site defaults to dark mode and includes a persistent manual `light` toggle.
 - Shared rail navigation and the column-grid toggle are used across the homepage, About, Colophon, and work pages.
-- For job-application attribution links, use `https://nieder.me/?utm_source=<company>&utm_medium=job_application&utm_campaign=portfolio`; add `&utm_content=<role_slug>` only when role-level detail is useful.
+- For job-application attribution links, use `https://nieder.me/?utm_source=<company>&utm_medium=job_application&utm_campaign=portfolio`; add `&utm_content=<role_slug>` when role-level detail is useful, and add `&share_id=<opaque_link_id>` when you want to attribute a specific shared outreach link across the visit.
 - The README should describe the current repo shape and workflows, not act as a running change log. If a feature ships, update the relevant section above instead of appending historical bullets.

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -12,8 +12,159 @@ const themeColorMeta = document.querySelector('meta[name="theme-color"]');
 const colorSchemeMeta = document.querySelector('meta[name="color-scheme"]');
 const THEME_STORAGE_KEY = "nieder.theme";
 const COLS_TOGGLE_STORAGE_KEY = "nieder.cols-grid-visible";
+const SHARE_CONTEXT_STORAGE_KEY = "nieder.analytics.share_context";
 const LIGHT_THEME_COLOR = "#ffffff";
 const DARK_THEME_COLOR = "#000000";
+
+const safeParseJson = (value) => {
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    return null;
+  }
+};
+
+const getShareContext = () => {
+  const params = new URLSearchParams(window.location.search);
+  const shareId = String(params.get("share_id") || "").trim();
+
+  if (shareId) {
+    const nextContext = {
+      shareId,
+      source: String(params.get("utm_source") || "").trim(),
+      medium: String(params.get("utm_medium") || "").trim(),
+      campaign: String(params.get("utm_campaign") || "").trim(),
+      content: String(params.get("utm_content") || "").trim(),
+    };
+
+    try {
+      window.sessionStorage.setItem(SHARE_CONTEXT_STORAGE_KEY, JSON.stringify(nextContext));
+    } catch (error) {
+      // Ignore storage access failures and keep the current-page context only.
+    }
+
+    return nextContext;
+  }
+
+  try {
+    return safeParseJson(window.sessionStorage.getItem(SHARE_CONTEXT_STORAGE_KEY));
+  } catch (error) {
+    return null;
+  }
+};
+
+const shareContext = getShareContext();
+
+const getPageType = () => {
+  const path = window.location.pathname.replace(/\/+$/, "") || "/";
+  if (path === "/") return "home";
+  if (path === "/about") return "about";
+  if (path === "/work") return "work_index";
+  if (path === "/privacy") return "privacy";
+  if (path === "/accessibility") return "accessibility";
+  if (path === "/colophon") return "colophon";
+  if (/^\/work\/[^/]+$/.test(path)) return "case_study";
+  return "site_page";
+};
+
+const trackEvent = (eventName, params = {}) => {
+  if (typeof window.gtag !== "function") {
+    return;
+  }
+
+  window.gtag("event", eventName, {
+    page_path: window.location.pathname,
+    page_title: document.title,
+    share_id: shareContext?.shareId,
+    utm_source: shareContext?.source,
+    utm_medium: shareContext?.medium,
+    utm_campaign: shareContext?.campaign,
+    utm_content: shareContext?.content,
+    ...params,
+  });
+};
+
+{
+  if (shareContext?.shareId) {
+    trackEvent("shared_link_page_view", {
+      page_type: getPageType(),
+    });
+
+    let engagedTimer = null;
+    let engagedFired = false;
+
+    const queueEngagedTimer = () => {
+      if (engagedFired || document.visibilityState !== "visible") {
+        return;
+      }
+
+      window.clearTimeout(engagedTimer);
+      engagedTimer = window.setTimeout(() => {
+        engagedFired = true;
+        trackEvent("shared_link_engaged", {
+          page_type: getPageType(),
+          engaged_seconds: 20,
+        });
+      }, 20000);
+    };
+
+    document.addEventListener("visibilitychange", () => {
+      if (document.visibilityState === "visible") {
+        queueEngagedTimer();
+        return;
+      }
+
+      window.clearTimeout(engagedTimer);
+    });
+
+    queueEngagedTimer();
+  }
+}
+
+{
+  const trackedAnchors = Array.from(document.querySelectorAll("a[href]"));
+
+  trackedAnchors.forEach((anchor) => {
+    anchor.addEventListener("click", () => {
+      const rawHref = anchor.getAttribute("href");
+      if (!rawHref) {
+        return;
+      }
+
+      if (rawHref.startsWith("mailto:")) {
+        trackEvent("email_clicked", {
+          destination: rawHref,
+          link_label: anchor.textContent.trim() || anchor.getAttribute("aria-label") || "email",
+        });
+        return;
+      }
+
+      const isResumeDownload = anchor.hasAttribute("download") && /\.pdf($|\?)/i.test(rawHref);
+      if (isResumeDownload) {
+        trackEvent("resume_download_clicked", {
+          destination: rawHref,
+        });
+        return;
+      }
+
+      let destinationUrl;
+      try {
+        destinationUrl = new URL(rawHref, window.location.href);
+      } catch (error) {
+        return;
+      }
+
+      if (destinationUrl.origin !== window.location.origin) {
+        trackEvent("external_link_clicked", {
+          destination_host: destinationUrl.host,
+          destination_path: destinationUrl.pathname,
+          link_label: anchor.textContent.trim() || anchor.getAttribute("aria-label") || destinationUrl.host,
+        });
+      }
+    });
+  });
+}
+
 const scrollToPageTop = () => {
   window.scrollTo({ top: 0, behavior: "smooth" });
   if (window.location.hash) {

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -218,9 +218,11 @@
               <h2>Analytics and what this site does not currently do</h2>
               <p>
                 This site uses Google Analytics to understand aggregate traffic and engagement, such as page visits,
-                referral or campaign information, browser and device context, and broad interaction signals. The local
-                theme and column-grid preferences described above remain separate browser settings and are not used as
-                analytics identifiers.
+                referral or campaign information, browser and device context, and broad interaction signals. When I
+                share a portfolio link directly for a job conversation or outreach thread, that link may also include an
+                attribution token so I can understand how that shared visit moved through the site. The local theme and
+                column-grid preferences described above remain separate browser settings and are not used as analytics
+                identifiers.
               </p>
               <p>
                 This site does not currently use advertising, account registration, or payment processing. I do not


### PR DESCRIPTION
## Summary
- capture opaque shared-link attribution in session analytics context
- track a small set of high-signal outbound actions in GA4
- document shared-link attribution in the privacy page and README

## Verification
- node --check assets/js/main.js
- bash scripts/check-ga4-analytics.sh