### PR TITLE
refactor: clean up case study recirculation

### DIFF
--- a/assets/css/work-case-study.css
+++ b/assets/css/work-case-study.css
@@ -2486,7 +2486,7 @@ body.grid-hidden .work-grid-overlay > span {
 }
 
 .case-study-recirculation {
-  margin-top: 120px;
+  margin-top: 240px;
 }
 
 .case-study-recirculation > .rule {
@@ -2494,7 +2494,7 @@ body.grid-hidden .work-grid-overlay > span {
 }
 
 .case-study-recirculation.work-index-case-study-block {
-  margin-top: 120px;
+  margin-top: 240px;
 }
 
 .case-study-recirculation .work-index-case-studies {

--- a/assets/css/work-case-study.css
+++ b/assets/css/work-case-study.css
@@ -2497,6 +2497,10 @@ body.grid-hidden .work-grid-overlay > span {
   margin-top: 240px;
 }
 
+.case-study-recirculation .work-index-case-study-heading {
+  grid-column: 1 / span 3;
+}
+
 .case-study-recirculation .work-index-case-studies {
   grid-template-rows: none;
   grid-auto-flow: row;

--- a/work/ai-quota/index.html
+++ b/work/ai-quota/index.html
@@ -451,7 +451,7 @@
           <div class="rule"></div>
           <div class="work-article-grid work-index-case-study-layout">
             <div class="work-index-case-study-heading">
-              <h2 id="case-study-recirculation-title">Case Studies</h2>
+              <h2 id="case-study-recirculation-title">More Case Studies</h2>
             </div>
 
             <div class="work-index-case-studies">
@@ -459,8 +459,8 @@
                 <a class="work-index-card" href="../../work/resy-discovery/" aria-labelledby="case-study-resy-title">
                   <figure class="work-index-card-media">
                     <picture>
-                      <source media="(max-width: 700px)" srcset="../../assets/images/case-studies/resy-discovery/promo/card-mobile.png" />
-                      <img src="../../assets/images/case-studies/resy-discovery/promo/card-desktop.png" alt="Preview image for the Resy discovery case study" />
+                      <source media="(max-width: 700px)" srcset="../../assets/images/case-studies/resy-discovery/article/hero-mobile.jpg" />
+                      <img src="../../assets/images/case-studies/resy-discovery/article/hero-desktop.jpg" alt="Preview image for the Resy discovery case study" />
                     </picture>
                   </figure>
                   <div class="work-index-card-copy">
@@ -473,8 +473,8 @@
                 <a class="work-index-card" href="../../work/somm-ai/" aria-labelledby="case-study-sommai-title">
                   <figure class="work-index-card-media">
                     <picture>
-                      <source media="(max-width: 700px)" srcset="../../assets/images/case-studies/somm-ai/promo/card-mobile.png" />
-                      <img src="../../assets/images/case-studies/somm-ai/promo/card-desktop.png" alt="Preview image for the Somm AI case study" />
+                      <source media="(max-width: 700px)" srcset="../../assets/images/case-studies/somm-ai/article/hero-mobile.png" />
+                      <img src="../../assets/images/case-studies/somm-ai/article/hero-desktop.jpg" alt="Preview image for the Somm AI case study" />
                     </picture>
                   </figure>
                   <div class="work-index-card-copy">
@@ -489,8 +489,8 @@
                 <a class="work-index-card" href="../../work/sendmoi/" aria-labelledby="case-study-sendmoi-title">
                   <figure class="work-index-card-media">
                     <picture>
-                      <source media="(max-width: 700px)" srcset="../../assets/images/case-studies/sendmoi/promo/bg-SendMoi-desktop.png" />
-                      <img src="../../assets/images/case-studies/sendmoi/promo/bg-SendMoi-desktop.png" alt="Preview image for the SendMoi case study" />
+                      <source media="(max-width: 700px)" srcset="../../assets/images/case-studies/sendmoi/article/bg-SendMoi-desktop.png" />
+                      <img src="../../assets/images/case-studies/sendmoi/article/bg2-SendMoi.jpg" alt="Preview image for the SendMoi case study" />
                     </picture>
                   </figure>
                   <div class="work-index-card-copy">

--- a/work/resy-discovery/index.html
+++ b/work/resy-discovery/index.html
@@ -430,6 +430,26 @@
                 </div>
               </section>
 
+              <section class="case-study-block case-study-block-metrics case-study-block-metrics-3" aria-labelledby="resy-metrics-title">
+                <div class="case-study-block-inner">
+                  <h2 class="visually-hidden" id="resy-metrics-title">Key outcome metrics</h2>
+                  <div class="case-study-metrics" role="list">
+                    <article class="case-study-metric" role="listitem">
+                      <p class="case-study-metric-value"><span class="case-study-metric-prefix">+</span><span>20%</span></p>
+                      <p class="case-study-metric-label">MAU</p>
+                    </article>
+                    <article class="case-study-metric" role="listitem">
+                      <p class="case-study-metric-value"><span class="case-study-metric-prefix">+</span><span>14%</span></p>
+                      <p class="case-study-metric-label">Booking Conversion</p>
+                    </article>
+                    <article class="case-study-metric" role="listitem">
+                      <p class="case-study-metric-value"><span class="case-study-metric-prefix">+</span><span>17%</span></p>
+                      <p class="case-study-metric-label">Avg. Session Duration</p>
+                    </article>
+                  </div>
+                </div>
+              </section>
+
               <section class="work-article-section case-study-block case-study-block-results">
                 <div class="case-study-block-inner">
                   <h2>Early Signals</h2>
@@ -451,103 +471,7 @@
                 </div>
               </section>
 
-              <section class="case-study-block case-study-block-metrics case-study-block-metrics-3" aria-labelledby="resy-metrics-title">
-                <div class="case-study-block-inner">
-                  <h2 class="visually-hidden" id="resy-metrics-title">Key outcome metrics</h2>
-                  <div class="case-study-metrics" role="list">
-                    <article class="case-study-metric" role="listitem">
-                      <p class="case-study-metric-value"><span class="case-study-metric-prefix">+</span><span>20%</span></p>
-                      <p class="case-study-metric-label">MAU</p>
-                    </article>
-                    <article class="case-study-metric" role="listitem">
-                      <p class="case-study-metric-value"><span class="case-study-metric-prefix">+</span><span>14%</span></p>
-                      <p class="case-study-metric-label">Booking Conversion</p>
-                    </article>
-                    <article class="case-study-metric" role="listitem">
-                      <p class="case-study-metric-value"><span class="case-study-metric-prefix">+</span><span>17%</span></p>
-                      <p class="case-study-metric-label">Avg. Session Duration</p>
-                    </article>
-                  </div>
-                </div>
-              </section>
 
-
-
-              <section class="work-article-section case-study-block case-study-block-text">
-                <div class="case-study-block-inner">
-                  <h2>Context</h2>
-                  <p>
-                    The objective was to tighten that loop and increase meaningful exploration inside the app while keeping
-                    editorial inspiration, list-making, and booking momentum close together.
-                  </p>
-                  <p>
-                    The work focused on making discovery feel less like a disconnected browsing surface and more like a
-                    coherent path from curiosity to a real reservation.
-                  </p>
-                </div>
-              </section>
-
-              <section class="work-article-section case-study-block case-study-block-text">
-                <div class="case-study-block-inner">
-                  <h2>Challenge</h2>
-                  <p>
-                    Discovery had to serve different intents in the same session: browsing editorial stories, finding
-                    restaurants fast, and saving options for later. The product needed clearer hierarchy and stronger
-                    transitions across those intents without fragmenting the experience.
-                  </p>
-                </div>
-              </section>
-
-              <section class="work-article-section case-study-block case-study-block-text">
-                <div class="case-study-block-inner">
-                  <h2>Strategy</h2>
-                  <ul>
-                    <li>
-                      <strong>Research + journey mapping:</strong> identified breakpoints between discovery, list-making, and
-                      reservation triggers.
-                    </li>
-                    <li>
-                      <strong>Editorial-first discovery:</strong> structured the top of funnel around Resy editorial surfaces
-                      and algorithmic collections to improve relevance and recirculation.
-                    </li>
-                    <li>
-                      <strong>Navigation re-architecture:</strong> modernized interaction patterns with a more sheet-based,
-                      gesture-forward model to reduce friction.
-                    </li>
-                    <li>
-                      <strong>Cross-functional operating loop:</strong> aligned product, editorial, and engineering to keep
-                      the system coherent as feature velocity increased.
-                    </li>
-                  </ul>
-                </div>
-              </section>
-
-              <section class="case-study-block case-study-block-aside-media case-study-block-aside-right">
-                <div class="case-study-block-inner">
-                  <div class="case-study-copy">
-                    <h2>Support Moments</h2>
-                    <p>
-                      Smaller interventions mattered too. Curation and recommendation modules had to reinforce discovery
-                      without overwhelming the primary booking path.
-                    </p>
-                    <p>
-                      The surrounding surfaces were designed to keep diners oriented while still making room for editorial
-                      voice and secondary actions.
-                    </p>
-                  </div>
-                </div>
-              </section>
-
-              <section class="work-article-section case-study-block case-study-block-results">
-                <div class="case-study-block-inner">
-                  <h2>Outcome</h2>
-                  <p>
-                    The update tightened the path from curiosity to booking and gave content and product teams a shared
-                    surface they could evolve together. It also established a durable structure for future discovery
-                    iterations as the app scaled.
-                  </p>
-                </div>
-              </section>
 
               <section class="case-study-block case-study-block-reference-links" aria-labelledby="resy-reference-links-title">
                 <div class="case-study-block-inner">
@@ -585,188 +509,6 @@
 
 
 
-<br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/>
-
-
-              <section class="case-study-block case-study-block-full-media case-study-block-resy-demo">
-  <div class="case-study-block-inner">
-    <figure class="case-study-figure">
-      <div class="case-study-media case-study-resy-stage">
-        <div class="case-study-resy-device-shell">
-          <div class="case-study-resy-device-bezel">
-            <div class="case-study-sendmoi-video-frame">
-              <video
-                class="case-study-sendmoi-video-player"
-                src="../../assets/videos/resy-discovery-inline.mp4"
-                poster="../../assets/images/case-studies/resy-discovery/article/video-poster.jpg"
-                autoplay
-                muted
-                loop
-                playsinline
-                preload="metadata"
-                aria-label="Resy discovery demo video. Click, tap, or press Space to play or pause."
-                tabindex="0"
-                data-case-study-demo-video
-              >
-                Your browser does not support embedded video.
-              </video>
-              <span class="case-study-sendmoi-video-playhead" aria-hidden="true"></span>
-            </div>
-          </div>
-        </div>
-      </div>
-      <figcaption class="case-study-caption">
-        Live Resy discovery demo, showing how editorial modules, card detail, and booking entry points connect in motion.
-      </figcaption>
-    </figure>
-  </div>
-</section>
-
-
-<br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/>
-
-
-
-
-              <section class="case-study-block case-study-block-aside-media case-study-block-aside-right">
-                <div class="case-study-block-inner">
-                  <div class="case-study-copy">
-                    
-                  </div>
-                  <figure class="case-study-figure case-study-media-wrap">
-                    <div class="case-study-media">
-                      <img
-                        src="../../assets/images/case-studies/resy-discovery/article/frame-04.png"
-                        alt="Resy curation and recommendation surface."
-                        loading="lazy"
-                      />
-                    </div>
-                    <figcaption class="case-study-caption">Curated collections and recommendation continuity.</figcaption>
-                  </figure>
-                </div>
-              </section>
-
-
-<br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/>
-
-
-              <section class="case-study-block case-study-block-full-media">
-                <div class="case-study-block-inner">
-                  <figure class="case-study-figure">
-                    <div class="case-study-media">
-                      <img
-                        src="../../assets/images/case-studies/resy-discovery/article/frame-01.png"
-                        alt="Resy discovery feed with editorial-first modules."
-                        loading="lazy"
-                      />
-                    </div>
-                    <figcaption class="case-study-caption">Discovery feed and editorial module structure.</figcaption>
-                  </figure>
-                </div>
-              </section>
-              
-<br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/>
-
-              <section class="case-study-block case-study-block-two-up">
-                <div class="case-study-block-inner">
-                  <figure class="case-study-figure">
-                    <div class="case-study-media">
-                      <img
-                        src="../../assets/images/case-studies/resy-discovery/article/frame-02.png"
-                        alt="Resy restaurant card and recommendation patterns."
-                        loading="lazy"
-                      />
-                    </div>
-                    <figcaption class="case-study-caption">Content-to-card transitions inside discovery.</figcaption>
-                  </figure>
-                  <figure class="case-study-figure">
-                    <div class="case-study-media">
-                      <img
-                        src="../../assets/images/case-studies/resy-discovery/article/frame-03.png"
-                        alt="Resy in-app list and booking entry points."
-                        loading="lazy"
-                      />
-                    </div>
-                    <figcaption class="case-study-caption">Add-to-Lists and booking entry points stayed close to the feed.</figcaption>
-                  </figure>
-                </div>
-              </section>
-
-<br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/>
-
-              <section class="case-study-block case-study-block-carousel" aria-label="Resy discovery sequence">
-                <div class="case-study-block-inner">
-                  <div class="case-study-carousel-controls" hidden>
-                    <button class="case-study-carousel-button" type="button" data-carousel-prev aria-label="Previous slide">
-                      Prev
-                    </button>
-                    <button class="case-study-carousel-button" type="button" data-carousel-next aria-label="Next slide">
-                      Next
-                    </button>
-                    <p class="case-study-carousel-status" data-carousel-status>1 / 5</p>
-                  </div>
-                  <div class="case-study-carousel-track">
-                    <figure class="case-study-figure case-study-carousel-slide">
-                      <div class="case-study-media">
-                        <img
-                          src="../../assets/images/case-studies/resy-discovery/article/frame-01.png"
-                          alt="Resy discovery feed with editorial-first modules."
-                          loading="lazy"
-                        />
-                      </div>
-                      <figcaption class="case-study-caption">Discovery feed and editorial module structure.</figcaption>
-                    </figure>
-                    <figure class="case-study-figure case-study-carousel-slide">
-                      <div class="case-study-media">
-                        <img
-                          src="../../assets/images/case-studies/resy-discovery/article/frame-02.png"
-                          alt="Resy restaurant card and recommendation patterns."
-                          loading="lazy"
-                        />
-                      </div>
-                      <figcaption class="case-study-caption">Content-to-card transitions inside discovery.</figcaption>
-                    </figure>
-                    <figure class="case-study-figure case-study-carousel-slide">
-                      <div class="case-study-media">
-                        <img
-                          src="../../assets/images/case-studies/resy-discovery/article/frame-03.png"
-                          alt="Resy in-app list and booking entry points."
-                          loading="lazy"
-                        />
-                      </div>
-                      <figcaption class="case-study-caption">Add-to-Lists and booking entry points.</figcaption>
-                    </figure>
-                    <figure class="case-study-figure case-study-carousel-slide">
-                      <div class="case-study-media">
-                        <img
-                          src="../../assets/images/case-studies/resy-discovery/article/frame-04.png"
-                          alt="Resy curation and recommendation surface."
-                          loading="lazy"
-                        />
-                      </div>
-                      <figcaption class="case-study-caption">Curated collections and recommendation continuity.</figcaption>
-                    </figure>
-                    <figure class="case-study-figure case-study-carousel-slide">
-                      <div class="case-study-media">
-                        <img
-                          src="../../assets/images/case-studies/resy-discovery/article/frame-05.png"
-                          alt="Resy discovery detail and booking flow integration."
-                          loading="lazy"
-                        />
-                      </div>
-                      <figcaption class="case-study-caption">Detail surface integrated with downstream actions.</figcaption>
-                    </figure>
-                  </div>
-                </div>
-              </section>
-
-<br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/>
-
-
-
-
-
-
             </article>
           </section>
         </div>
@@ -775,7 +517,7 @@
           <div class="rule"></div>
           <div class="work-article-grid work-index-case-study-layout">
             <div class="work-index-case-study-heading">
-              <h2 id="case-study-recirculation-title">Case Studies</h2>
+              <h2 id="case-study-recirculation-title">More Case Studies</h2>
             </div>
 
             <div class="work-index-case-studies">
@@ -783,8 +525,8 @@
                 <a class="work-index-card" href="../../work/ai-quota/" aria-labelledby="case-study-aiquota-title">
                   <figure class="work-index-card-media">
                     <picture>
-                      <source media="(max-width: 700px)" srcset="../../assets/images/case-studies/ai-quota/promo/bg-aiquota-promo-mobile.jpg" />
-                      <img src="../../assets/images/case-studies/ai-quota/promo/bg-aiquota-promo-desktop.jpg" alt="Preview image for the AIQuota case study" />
+                      <source media="(max-width: 700px)" srcset="../../assets/images/case-studies/ai-quota/article/hero-composite-screenshot-current.jpg" />
+                      <img src="../../assets/images/case-studies/ai-quota/article/hero-composite-screenshot-current.jpg" alt="Preview image for the AIQuota case study" />
                     </picture>
                   </figure>
                   <div class="work-index-card-copy">
@@ -797,8 +539,8 @@
                 <a class="work-index-card" href="../../work/somm-ai/" aria-labelledby="case-study-sommai-title">
                   <figure class="work-index-card-media">
                     <picture>
-                      <source media="(max-width: 700px)" srcset="../../assets/images/case-studies/somm-ai/promo/card-mobile.png" />
-                      <img src="../../assets/images/case-studies/somm-ai/promo/card-desktop.png" alt="Preview image for the Somm AI case study" />
+                      <source media="(max-width: 700px)" srcset="../../assets/images/case-studies/somm-ai/article/hero-mobile.png" />
+                      <img src="../../assets/images/case-studies/somm-ai/article/hero-desktop.jpg" alt="Preview image for the Somm AI case study" />
                     </picture>
                   </figure>
                   <div class="work-index-card-copy">
@@ -813,8 +555,8 @@
                 <a class="work-index-card" href="../../work/sendmoi/" aria-labelledby="case-study-sendmoi-title">
                   <figure class="work-index-card-media">
                     <picture>
-                      <source media="(max-width: 700px)" srcset="../../assets/images/case-studies/sendmoi/promo/bg-SendMoi-desktop.png" />
-                      <img src="../../assets/images/case-studies/sendmoi/promo/bg-SendMoi-desktop.png" alt="Preview image for the SendMoi case study" />
+                      <source media="(max-width: 700px)" srcset="../../assets/images/case-studies/sendmoi/article/bg-SendMoi-desktop.png" />
+                      <img src="../../assets/images/case-studies/sendmoi/article/bg2-SendMoi.jpg" alt="Preview image for the SendMoi case study" />
                     </picture>
                   </figure>
                   <div class="work-index-card-copy">

--- a/work/sendmoi/index.html
+++ b/work/sendmoi/index.html
@@ -452,7 +452,7 @@
           <div class="rule"></div>
           <div class="work-article-grid work-index-case-study-layout">
             <div class="work-index-case-study-heading">
-              <h2 id="case-study-recirculation-title">Case Studies</h2>
+              <h2 id="case-study-recirculation-title">More Case Studies</h2>
             </div>
 
             <div class="work-index-case-studies">
@@ -460,8 +460,8 @@
                 <a class="work-index-card" href="../../work/resy-discovery/" aria-labelledby="case-study-resy-title">
                   <figure class="work-index-card-media">
                     <picture>
-                      <source media="(max-width: 700px)" srcset="../../assets/images/case-studies/resy-discovery/promo/card-mobile.png" />
-                      <img src="../../assets/images/case-studies/resy-discovery/promo/card-desktop.png" alt="Preview image for the Resy discovery case study" />
+                      <source media="(max-width: 700px)" srcset="../../assets/images/case-studies/resy-discovery/article/hero-mobile.jpg" />
+                      <img src="../../assets/images/case-studies/resy-discovery/article/hero-desktop.jpg" alt="Preview image for the Resy discovery case study" />
                     </picture>
                   </figure>
                   <div class="work-index-card-copy">
@@ -474,8 +474,8 @@
                 <a class="work-index-card" href="../../work/ai-quota/" aria-labelledby="case-study-aiquota-title">
                   <figure class="work-index-card-media">
                     <picture>
-                      <source media="(max-width: 700px)" srcset="../../assets/images/case-studies/ai-quota/promo/bg-aiquota-promo-mobile.jpg" />
-                      <img src="../../assets/images/case-studies/ai-quota/promo/bg-aiquota-promo-desktop.jpg" alt="Preview image for the AIQuota case study" />
+                      <source media="(max-width: 700px)" srcset="../../assets/images/case-studies/ai-quota/article/hero-composite-screenshot-current.jpg" />
+                      <img src="../../assets/images/case-studies/ai-quota/article/hero-composite-screenshot-current.jpg" alt="Preview image for the AIQuota case study" />
                     </picture>
                   </figure>
                   <div class="work-index-card-copy">
@@ -490,8 +490,8 @@
                 <a class="work-index-card" href="../../work/somm-ai/" aria-labelledby="case-study-sommai-title">
                   <figure class="work-index-card-media">
                     <picture>
-                      <source media="(max-width: 700px)" srcset="../../assets/images/case-studies/somm-ai/promo/card-mobile.png" />
-                      <img src="../../assets/images/case-studies/somm-ai/promo/card-desktop.png" alt="Preview image for the Somm AI case study" />
+                      <source media="(max-width: 700px)" srcset="../../assets/images/case-studies/somm-ai/article/hero-mobile.png" />
+                      <img src="../../assets/images/case-studies/somm-ai/article/hero-desktop.jpg" alt="Preview image for the Somm AI case study" />
                     </picture>
                   </figure>
                   <div class="work-index-card-copy">

--- a/work/somm-ai/index.html
+++ b/work/somm-ai/index.html
@@ -311,7 +311,7 @@
           <div class="rule"></div>
           <div class="work-article-grid work-index-case-study-layout">
             <div class="work-index-case-study-heading">
-              <h2 id="case-study-recirculation-title">Case Studies</h2>
+              <h2 id="case-study-recirculation-title">More Case Studies</h2>
             </div>
 
             <div class="work-index-case-studies">
@@ -319,8 +319,8 @@
                 <a class="work-index-card" href="../../work/resy-discovery/" aria-labelledby="case-study-resy-title">
                   <figure class="work-index-card-media">
                     <picture>
-                      <source media="(max-width: 700px)" srcset="../../assets/images/case-studies/resy-discovery/promo/card-mobile.png" />
-                      <img src="../../assets/images/case-studies/resy-discovery/promo/card-desktop.png" alt="Preview image for the Resy discovery case study" />
+                      <source media="(max-width: 700px)" srcset="../../assets/images/case-studies/resy-discovery/article/hero-mobile.jpg" />
+                      <img src="../../assets/images/case-studies/resy-discovery/article/hero-desktop.jpg" alt="Preview image for the Resy discovery case study" />
                     </picture>
                   </figure>
                   <div class="work-index-card-copy">
@@ -333,8 +333,8 @@
                 <a class="work-index-card" href="../../work/ai-quota/" aria-labelledby="case-study-aiquota-title">
                   <figure class="work-index-card-media">
                     <picture>
-                      <source media="(max-width: 700px)" srcset="../../assets/images/case-studies/ai-quota/promo/bg-aiquota-promo-mobile.jpg" />
-                      <img src="../../assets/images/case-studies/ai-quota/promo/bg-aiquota-promo-desktop.jpg" alt="Preview image for the AIQuota case study" />
+                      <source media="(max-width: 700px)" srcset="../../assets/images/case-studies/ai-quota/article/hero-composite-screenshot-current.jpg" />
+                      <img src="../../assets/images/case-studies/ai-quota/article/hero-composite-screenshot-current.jpg" alt="Preview image for the AIQuota case study" />
                     </picture>
                   </figure>
                   <div class="work-index-card-copy">
@@ -349,8 +349,8 @@
                 <a class="work-index-card" href="../../work/sendmoi/" aria-labelledby="case-study-sendmoi-title">
                   <figure class="work-index-card-media">
                     <picture>
-                      <source media="(max-width: 700px)" srcset="../../assets/images/case-studies/sendmoi/promo/bg-SendMoi-desktop.png" />
-                      <img src="../../assets/images/case-studies/sendmoi/promo/bg-SendMoi-desktop.png" alt="Preview image for the SendMoi case study" />
+                      <source media="(max-width: 700px)" srcset="../../assets/images/case-studies/sendmoi/article/bg-SendMoi-desktop.png" />
+                      <img src="../../assets/images/case-studies/sendmoi/article/bg2-SendMoi.jpg" alt="Preview image for the SendMoi case study" />
                     </picture>
                   </figure>
                   <div class="work-index-card-copy">


### PR DESCRIPTION
## Summary
- trim the Resy case study so it ends cleanly after the related coverage card
- increase the spacing before case study recirculation and rename the section to More Case Studies
- switch recirculation cards from promo assets to canonical article art

## Verification
- git diff --check