### PR TITLE
Polish colophon style guide annotations

### DIFF
--- a/assets/css/styleguide.css
+++ b/assets/css/styleguide.css
@@ -747,6 +747,10 @@
   gap: 12px;
 }
 
+#grid .styleguide-section-intro {
+  margin-bottom: 18px;
+}
+
 .styleguide-grid-demo span {
   height: 180px;
   background: color-mix(in srgb, var(--accent) 25%, transparent);
@@ -971,6 +975,15 @@
   .styleguide-patterns,
   .styleguide-responsive-specimen {
     grid-template-columns: 1fr;
+  }
+
+  .styleguide-color-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 12px;
+  }
+
+  .styleguide-swatch-card {
+    min-width: 0;
   }
 
   .styleguide-token-table-head {

--- a/assets/css/work-case-study.css
+++ b/assets/css/work-case-study.css
@@ -497,7 +497,7 @@ body.is-pulling-refresh .rail::after {
   pointer-events: none;
   opacity: 0;
   overflow: visible;
-  width: 180px;
+  width: 220px;
   transition: opacity 0.22s ease, transform 0.22s ease;
 }
 
@@ -510,7 +510,6 @@ body.is-pulling-refresh .rail::after {
   font-weight: 300;
   letter-spacing: 0;
   line-height: 1.35;
-  text-transform: lowercase;
   white-space: nowrap;
 }
 
@@ -527,11 +526,26 @@ body.is-pulling-refresh .rail::after {
   transform: translateX(8px);
 }
 
+.cols-toggle-cue-desktop {
+  left: 78px;
+  top: 88px;
+  transform: translateX(8px);
+}
+
 .theme-toggle-cue-mobile {
   display: none;
 }
 
-body.is-color-section-active .theme-toggle-cue-desktop {
+.cols-toggle-cue-mobile {
+  display: none;
+}
+
+body.is-color-section-active .theme-toggle.is-off + .theme-toggle-cue-desktop {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+body.is-grid-section-active .cols-toggle-cue-desktop {
   opacity: 1;
   transform: translateX(0);
 }
@@ -4380,30 +4394,53 @@ body.grid-hidden .work-grid-overlay > span {
     display: none;
   }
 
+  .cols-toggle-cue-desktop {
+    display: none;
+  }
+
   .mobile-nav-toggles {
     position: relative;
   }
 
   .theme-toggle-cue-mobile {
     display: block;
-    right: 16px;
+    right: 74px;
     bottom: calc(100% + 4px);
-    width: 142px;
+    width: 174px;
     transform: translateY(8px);
   }
 
-  .theme-toggle-cue-mobile .theme-toggle-cue-text {
-    margin-left: 38px;
+  .cols-toggle-cue-mobile {
+    display: block;
+    right: 42px;
+    bottom: calc(100% + 4px);
+    width: 188px;
+    transform: translateY(8px);
+  }
+
+  .theme-toggle-cue-mobile .theme-toggle-cue-text,
+  .cols-toggle-cue-mobile .theme-toggle-cue-text {
+    margin-left: 0;
+    margin-right: 46px;
+    text-align: right;
     font-size: 18px;
   }
 
-  .theme-toggle-cue-mobile .theme-toggle-cue-arrow {
+  .theme-toggle-cue-mobile .theme-toggle-cue-arrow,
+  .cols-toggle-cue-mobile .theme-toggle-cue-arrow {
     width: 42px;
     height: auto;
+    margin-left: auto;
     margin-top: -5px;
+    transform: scale(-1);
   }
 
-  body.is-color-section-active .theme-toggle-cue-mobile {
+  body.is-color-section-active .theme-toggle.is-off + .theme-toggle-cue-mobile {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  body.is-grid-section-active .cols-toggle-cue-mobile {
     opacity: 1;
     transform: translateY(0);
   }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -633,35 +633,50 @@ if (homeRailNav) {
 
 {
   const colorSection = document.querySelector("#color");
+  const gridSection = document.querySelector("#grid");
 
-  if (colorSection) {
-    const setColorSectionActive = (isActive) => {
-      document.body.classList.toggle("is-color-section-active", isActive);
+  if (colorSection && gridSection) {
+    const cueClasses = ["is-color-section-active", "is-grid-section-active"];
+    const colorActivationOffset = 200;
+    const cueScrollWindow = 340;
+    const getPageTop = (element) =>
+      Math.round(element.getBoundingClientRect().top + window.scrollY);
+
+    let cueFrame = null;
+
+    const updateSectionCues = () => {
+      const colorStart = getPageTop(colorSection) - colorActivationOffset;
+      const gridStart = getPageTop(gridSection) - Math.round(window.innerHeight / 2);
+      const gridScrollWindow = window.matchMedia("(max-width: 700px)").matches
+        ? Math.max(cueScrollWindow, Math.round(window.innerHeight / 2) + 160)
+        : cueScrollWindow;
+      const isColorActive =
+        window.scrollY >= colorStart && window.scrollY < colorStart + cueScrollWindow;
+      const isGridActive =
+        window.scrollY >= gridStart && window.scrollY < gridStart + gridScrollWindow;
+      let activeClass = "";
+
+      if (isColorActive) {
+        activeClass = "is-color-section-active";
+      } else if (isGridActive) {
+        activeClass = "is-grid-section-active";
+      }
+
+      cueClasses.forEach((className) => {
+        document.body.classList.toggle(className, className === activeClass);
+      });
+      cueFrame = null;
     };
 
-    if ("IntersectionObserver" in window) {
-      const observer = new IntersectionObserver(
-        (entries) => {
-          setColorSectionActive(entries.some((entry) => entry.isIntersecting));
-        },
-        {
-          rootMargin: "-34% 0px -38% 0px",
-          threshold: 0,
-        }
-      );
+    const queueSectionCueUpdate = () => {
+      if (cueFrame) return;
+      cueFrame = window.requestAnimationFrame(updateSectionCues);
+    };
 
-      observer.observe(colorSection);
-    } else {
-      const updateColorSectionActive = () => {
-        const rect = colorSection.getBoundingClientRect();
-        const activationY = window.innerHeight * 0.42;
-        setColorSectionActive(rect.top <= activationY && rect.bottom >= activationY);
-      };
-
-      updateColorSectionActive();
-      window.addEventListener("scroll", updateColorSectionActive, { passive: true });
-      window.addEventListener("resize", updateColorSectionActive);
-    }
+    updateSectionCues();
+    window.addEventListener("scroll", queueSectionCueUpdate, { passive: true });
+    window.addEventListener("resize", queueSectionCueUpdate);
+    window.addEventListener("hashchange", queueSectionCueUpdate);
   }
 }
 

--- a/colophon-style-guide/index.html
+++ b/colophon-style-guide/index.html
@@ -77,7 +77,7 @@
             <span class="theme-toggle-state" aria-live="polite">Off</span>
           </button>
           <div class="theme-toggle-cue theme-toggle-cue-mobile" aria-hidden="true">
-            <span class="theme-toggle-cue-text">click me</span>
+            <span class="theme-toggle-cue-text">Light Mode!</span>
             <img class="theme-toggle-cue-arrow" src="../assets/icons/theme-toggle-cue-arrow.svg" alt="" />
           </div>
           <button class="cols-toggle is-off" type="button" aria-pressed="false" aria-label="Show column grid">
@@ -85,6 +85,10 @@
             <span class="cols-toggle-label">cols</span>
             <span class="cols-toggle-state" aria-live="polite">Off</span>
           </button>
+          <div class="theme-toggle-cue cols-toggle-cue-mobile" aria-hidden="true">
+            <span class="theme-toggle-cue-text">Column Grid!</span>
+            <img class="theme-toggle-cue-arrow" src="../assets/icons/theme-toggle-cue-arrow.svg" alt="" />
+          </div>
         </div>
       </nav>
 
@@ -126,7 +130,7 @@
             <span class="theme-toggle-state" aria-live="polite">Off</span>
           </button>
           <div class="theme-toggle-cue theme-toggle-cue-desktop" aria-hidden="true">
-            <span class="theme-toggle-cue-text">click me</span>
+            <span class="theme-toggle-cue-text">Light Mode!</span>
             <img class="theme-toggle-cue-arrow" src="../assets/icons/theme-toggle-cue-arrow.svg" alt="" />
           </div>
           <button class="cols-toggle is-off" type="button" aria-pressed="false" aria-label="Show column grid">
@@ -134,6 +138,10 @@
             <span class="cols-toggle-label">cols</span>
             <span class="cols-toggle-state" aria-live="polite">Off</span>
           </button>
+          <div class="theme-toggle-cue cols-toggle-cue-desktop" aria-hidden="true">
+            <span class="theme-toggle-cue-text">Column Grid!</span>
+            <img class="theme-toggle-cue-arrow" src="../assets/icons/theme-toggle-cue-arrow.svg" alt="" />
+          </div>
         </div>
       </nav>
 
@@ -186,8 +194,7 @@
               <p>
                 The site is set in
                 <a href="https://klim.co.nz/fonts/soehne/" target="_blank" rel="noopener noreferrer">S&#246;hne</a>,
-                mostly in Leicht, Buch, and Halbfett cuts. Italics are reserved for contrast, emphasis, and the
-                occasional raised eyebrow.
+                mostly in Leicht, Buch, and Halbfett cuts. Italics are reserved for contrast and emphasis.
               </p>
             </section>
 


### PR DESCRIPTION
## Summary
- Rename the rail annotations to “Light Mode!” and “Column Grid!” and add a dedicated Grid cue for desktop and mobile.
- Refactor annotation timing so Color and Grid cues are mutually exclusive, with Grid triggering at the viewport midpoint.
- Tune mobile behavior: two-column color swatches, mirrored mobile arrows, and separate placement for light/cols toggles.
- Tighten Grid section spacing and simplify the Söhne materials copy.

## Verification
- `bash ./scripts/check-ga4-analytics.sh`
- `python3 ./scripts/check-deploy-2026.py`
- `bash ./scripts/check-launch-case-studies.sh`
- Live preview checked at `http://localhost:8002/colophon-style-guide/` across desktop and mobile annotation states.