### PR TITLE
Refresh repo docs after launch updates

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,41 +1,34 @@
 # Handoff
 
 ## Branch
-- `codex/ipad-nav-hover`
+- `codex/docs-refresh`
 
 ## Current Focus
-- Mobile navigation review and fixes after wrapping the recent iPad rail, deploy cache-busting, and work-index top-band cleanup.
+- Documentation audit after the 2026 site launch work landed on `main`.
 
 ## Tracking
-- GitHub issue `#74` tracks the sticky iPad hover state on the left/global rail navigation.
+- No GitHub issue is currently attached to this docs refresh.
 
 ## What Changed
-- Updated shared rail hover behavior in `assets/css/styles.css` and `assets/css/work-case-study.css` so hover-only icon art and rail popovers appear only on hover-capable pointers.
-- Preserved `:focus-visible` behavior for keyboard users so the rail still exposes clear focus states on desktop.
-- Added a compact desktop `/work` layout range for `960px` to `1500px` in `assets/css/work-case-study.css` so iPad landscape widths keep the new global rail visible while shifting and tightening the content grid beside it.
-- Narrowed the dated resume column spacing and widened the case-study section flow in that compact range to avoid the overlapping/oversized layout shown on iPad.
-- Fixed `/2026/work/` stale-asset deploy behavior by bumping the work-family asset query strings and teaching `scripts/deploy-2026.sh` to rewrite staged `work-case-study.css` and `main.js` URLs across staged HTML with fresh content hashes.
-- Added a work-index-only top mask in `assets/css/work-case-study.css` so the empty header band stays solid black when the persisted column grid is enabled, instead of picking up the lighter gray overlay seen in device video.
-- Reviewed the recorded “safe area” issue and confirmed the main visible artifact was the column-grid tint in the work index top band, not the earlier pull-refresh theory. Commit `da68d80` was explicitly reverted by `e875bd2`.
-- Updated `README.md` so the deploy section matches the current cache-busting behavior.
+- Refreshed `README.md` so the current site surface distinguishes live case studies from public "Coming Soon" teaser cards and preserved drafts.
+- Added the `colophon/` and `styleguide/` legacy redirect pages to the README surface list.
+- Documented that `assets/css/styleguide.css` is part of the core style stack.
+- Updated the worktree example to use repo-local `.worktrees/`, matching the repo convention.
+- Clarified that staged deploys include redirect pages and exclude `drafts/`.
 
 ## Verification
 - `git diff --check`
-- Playwright check at `1194x834` on `/work/` confirming the global rail is visible and content starts to the right of it.
-- Local preview via `make dev-thread` on `http://Niederstudio.local:7778`
-- Playwright spot checks on `/work/` with the grid overlay forced on at narrow and wider viewports, confirming the top work-index band stays black.
+- `bash scripts/check-launch-case-studies.sh`
+- `python3 scripts/check-deploy-2026.py`
 
 ## Open Items
-- PR `#75` should include `Closes #74` in the body.
-- Validate on physical iPad that the rail no longer sticks in hover state and `/work/` reads cleanly in landscape.
-- Next task is a mobile nav pass. Start by reviewing `/` and `/work/` at phone widths and deciding whether the current mobile treatment should hide, simplify, or restyle the rail/navigation controls.
+- None.
 
 ## Resume Checklist
 1. `git branch --show-current`
 2. `git status --short --branch`
 3. Review `README.md` and `HANDOFF.md`
 4. Run `git diff --check`
-5. Preview `/` and `/work/` on mobile widths first, then re-check iPad/tablet widths
-6. If deploying, run `./scripts/deploy-2026.sh` from this branch so the staged asset hashes refresh
-7. Push `codex/ipad-nav-hover`
-8. Update PR `#75` with `Closes #74`
+5. Run `bash scripts/check-launch-case-studies.sh`
+6. Run `python3 scripts/check-deploy-2026.py`
+7. If rendered site files change later, start or reuse a preview and include the exact URL

--- a/README.md
+++ b/README.md
@@ -11,13 +11,16 @@ Current site surfaces:
 - `/` homepage with work highlights and a short About section
 - `/about/` full biography page
 - `/colophon-style-guide/` combined colophon and style guide
+- `/colophon/` legacy redirect to `/colophon-style-guide/`
+- `/styleguide/` legacy redirect to `/colophon-style-guide/#principles`
 - `/accessibility/` accessibility statement
 - `/privacy/` privacy notice
 - `/work/` full work experience and resume page
 - `/work/resy-discovery/` Resy case study
 - `/work/ai-quota/` AIQuota case study
-- `drafts/work/sendmoi/` preserved SendMoi case study draft, not deployed
-- `drafts/work/somm-ai/` preserved Somm AI case study draft, not deployed
+- public "Coming Soon" teaser cards for SendMoi and Somm AI on `/` and `/work/`
+- `drafts/work/sendmoi/` preserved SendMoi case study draft, not deployed or linked
+- `drafts/work/somm-ai/` preserved Somm AI case study draft, not deployed or linked
 
 Core project files:
 
@@ -25,9 +28,10 @@ Core project files:
 - `work/**/*.html` work index and case-study pages
 - `assets/css/styles.css` homepage and shared site styles
 - `assets/css/work-case-study.css` work index and case-study styles
+- `assets/css/styleguide.css` colophon and style-guide styles
 - `assets/js/main.js` shared client-side behavior
 - `assets/` images, icons, fonts, and video
-- `scripts/` local helpers for deploy and GitHub issue creation
+- `scripts/` local helpers for deploy, verification, and GitHub issue creation
 - `Makefile` preview, live-reload, and helper commands
 
 ## Local dev
@@ -113,7 +117,7 @@ git switch -c codex/my-feature
 Example worktree:
 
 ```bash
-git worktree add ../nieder-me-my-feature -b codex/my-feature
+git worktree add .worktrees/my-feature -b codex/my-feature
 ```
 
 ## Deploy
@@ -133,6 +137,8 @@ The script:
 
 - stages a temporary copy of `index.html` and `assets/`
 - includes allowlisted top-level sections when present
+- includes the legacy `colophon/` and `styleguide/` redirect pages
+- excludes `drafts/`
 - rewrites the staged homepage site URL
 - cache-busts staged CSS and JS asset URLs across all HTML files
 - syncs only managed paths to the remote target


### PR DESCRIPTION
## Summary
- Update README site-surface notes to distinguish live case studies from public "Coming Soon" teaser cards and preserved draft case studies.
- Document legacy redirect pages, the styleguide stylesheet, verification scripts, and deploy behavior for redirects/drafts.
- Refresh HANDOFF.md so the branch notes reflect the current docs audit instead of the older iPad-nav handoff.

## Verification
- git diff --check
- bash scripts/check-launch-case-studies.sh
- python3 scripts/check-deploy-2026.py

## Preview
- Not started; this is a docs-only change with no rendered site files modified.