### PR TITLE
Inset work and policy page headers

### DIFF
--- a/assets/css/work-case-study.css
+++ b/assets/css/work-case-study.css
@@ -3018,6 +3018,13 @@ body.grid-hidden .work-grid-overlay > span {
     margin-left: calc((100vw - var(--grid-width)) / 2 + 50px);
     margin-right: calc((100vw - var(--grid-width)) / 2 - 50px);
   }
+
+  .policy-page .work-index-header-copy,
+  .work-index-page .work-index-header-copy,
+  .work-index-page .work-index-lede,
+  .work-index-page .work-index-download-wrap {
+    margin-left: var(--case-study-edge-inset);
+  }
 }
 
 @media (min-width: 960px) and (max-width: 1500px) {


### PR DESCRIPTION
## Summary
- inset wide-desktop policy page headers by one content column
- match the /work header, lede, and download CTA to the same left rail alignment

## Validation
- git diff --check
- previewed locally via make dev-local on port 8001