### PR TITLE
Refresh policy page metadata

### DIFF
--- a/accessibility/index.html
+++ b/accessibility/index.html
@@ -8,7 +8,7 @@
     <title>Accessibility | John Niedermeyer</title>
     <meta
       name="description"
-      content="Accessibility statement for John Niedermeyer's portfolio, including current goals, known limitations, and contact information."
+      content="Accessibility statement for John Niedermeyer's portfolio, including the WCAG 2.2 AA target, known limitations, and contact information."
     />
     <script>
       (() => {
@@ -160,7 +160,7 @@
               </div>
               <div class="work-article-meta-card">
                 <p class="work-article-meta-label">Updated</p>
-                <p class="work-article-meta-value">April 4, 2026</p>
+                <p class="work-article-meta-value">April 22, 2026</p>
               </div>
             </div>
           </aside>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -8,7 +8,7 @@
     <title>Privacy | John Niedermeyer</title>
     <meta
       name="description"
-      content="Privacy notice for John Niedermeyer's portfolio, covering browser storage, email contact, hosting logs, and third-party links."
+      content="Privacy notice for John Niedermeyer's portfolio, covering browser storage, Google Analytics, email contact, hosting logs, and third-party links."
     />
     <script>
       (() => {
@@ -160,7 +160,7 @@
               </div>
               <div class="work-article-meta-card">
                 <p class="work-article-meta-label">Updated</p>
-                <p class="work-article-meta-value">April 4, 2026</p>
+                <p class="work-article-meta-value">April 22, 2026</p>
               </div>
             </div>
           </aside>

--- a/scripts/check-policy-pages.sh
+++ b/scripts/check-policy-pages.sh
@@ -132,10 +132,10 @@ expect_multiline_pattern "assets/css/work-case-study.css" \
   '\.logo-link \{[^}]*position: fixed;[^}]*width: 93\.832px;[^}]*height: 93\.832px;' \
   "Expected the desktop logo link to own the fixed clickable hit area."
 expect_multiline_pattern "assets/css/work-case-study.css" \
-  '\.logo-mark \{[^}]*cursor: pointer;[^}]*pointer-events: auto;' \
-  "Expected the visible desktop logo mark itself to remain an active hover target."
-expect_pattern "assets/css/work-case-study.css" '.logo-link:hover .logo-mark' \
-  "Expected the logo link to provide a visible hover cue."
+  '\.logo-mark \{[^}]*cursor: inherit;[^}]*pointer-events: auto;' \
+  "Expected the visible desktop logo mark to inherit the pointer cursor from the clickable logo link."
+expect_pattern "assets/css/work-case-study.css" '.logo-mark.is-brand-hover' \
+  "Expected the logo mark to provide a visible hover cue."
 expect_no_pattern "assets/css/work-case-study.css" 'site-footer-utility-separator' \
   "Expected footer utility links to use spacing instead of a slash separator style."
 


### PR DESCRIPTION
## Summary
- Update the privacy page meta description so it explicitly mentions Google Analytics.
- Update the accessibility page meta description to name the WCAG 2.2 AA target.
- Refresh the reviewed dates on both policy pages to April 22, 2026.
- Update stale policy-page verifier expectations for the current shared logo hover/cursor CSS contract.

## Verification
- bash scripts/check-policy-pages.sh
- bash scripts/check-ga4-analytics.sh
- git diff --check
- Served-page sanity checks against the local preview for /privacy/ and /accessibility/

## Preview
- http://Niederbook-Air-M4.local:8002/privacy/
- http://Niederbook-Air-M4.local:8002/accessibility/