### PR TITLE
Offset work experience on wide desktop

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1090,7 +1090,7 @@ body.grid-hidden .grid-overlay > span {
 }
 
 .experience-heading {
-  grid-column: 1 / span 3;
+  grid-column: 2 / span 3;
 }
 
 .experience-heading h3 {
@@ -1109,11 +1109,11 @@ body.grid-hidden .grid-overlay > span {
 }
 
 .experience-column:first-of-type {
-  grid-column: 4 / span 4;
+  grid-column: 5 / span 4;
 }
 
 .experience-column:last-of-type {
-  grid-column: 8 / span 4;
+  grid-column: 9 / span 4;
 }
 
 .experience-item h4 {


### PR DESCRIPTION
## Summary

- Offsets the homepage Work Experience grid one column to the right on wide desktop layouts
- Keeps the tablet and mobile layouts unchanged

## Verification

```text
python3 scripts/check-deploy-2026.py
./scripts/check-launch-case-studies.sh
./scripts/check-ga4-analytics.sh
git diff --check
```

Preview: `http://localhost:8001`
