### PR TITLE
Equalize mid-desktop work columns

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1137,6 +1137,10 @@ body.grid-hidden .grid-overlay > span {
   font-weight: 700;
 }
 
+.experience-item .experience-company-plain {
+  color: color-mix(in srgb, var(--muted) 70%, transparent);
+}
+
 .experience-item .experience-company a {
   display: inline-block;
   color: inherit;
@@ -2384,6 +2388,30 @@ body.grid-hidden .grid-overlay > span {
   .about-home-copy p {
     font-size: 18px;
     line-height: 1.35;
+  }
+}
+
+@media (min-width: 1280px) and (max-width: 1500px) {
+  .experience-grid {
+    grid-template-columns: repeat(var(--grid-cols), minmax(0, 1fr));
+    column-gap: var(--grid-gutter);
+    row-gap: 0;
+  }
+
+  .experience-heading {
+    grid-column: 2 / span 3;
+  }
+
+  .experience-columns-carousel {
+    display: contents;
+  }
+
+  .experience-column:first-of-type {
+    grid-column: 5 / span 4;
+  }
+
+  .experience-column:last-of-type {
+    grid-column: 9 / span 4;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -233,7 +233,7 @@
 
                 <article class="experience-item">
                   <h4>Indie Product/Designer/Engineer</h4>
-                  <p class="experience-company">Self</p>
+                  <p class="experience-company experience-company-plain">Self</p>
                   <p class="experience-date">Sept. 2025 - Present</p>
                 </article>
 


### PR DESCRIPTION
## Summary
- Use the 12-column Work Experience layout for upper mid-desktop widths so the two content columns keep matching 4-column spans.
- Style the homepage `Self` company label as a plain/non-linked company, matching the `/work` page treatment.

## Checks
- `python3 scripts/check-deploy-2026.py`
- `./scripts/check-launch-case-studies.sh`
- `./scripts/check-ga4-analytics.sh`
- `git diff --check`
