### PR TITLE
[codex] Add Resy Claude preface note

### DIFF
--- a/assets/css/work-case-study.css
+++ b/assets/css/work-case-study.css
@@ -16,9 +16,25 @@
 
 @font-face {
   font-family: "Sohne";
+  src: url("../fonts/soehne-buch-kursiv.woff2") format("woff2");
+  font-weight: 400;
+  font-style: italic;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "Sohne";
   src: url("../fonts/soehne-halbfett.woff2") format("woff2");
   font-weight: 700;
   font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "Sohne";
+  src: url("../fonts/soehne-halbfett-kursiv.woff2") format("woff2");
+  font-weight: 700;
+  font-style: italic;
   font-display: swap;
 }
 
@@ -1105,6 +1121,17 @@ body.grid-hidden .work-grid-overlay > span {
   margin: 0;
   color: var(--fg);
   text-wrap: pretty;
+}
+
+.case-study-preface {
+  padding: 16px 18px;
+  border: 1px solid var(--line);
+  border-radius: 15px;
+  font-style: italic;
+}
+
+.work-article-body > .case-study-block-preface + .case-study-block-intro-lede {
+  margin-top: var(--case-study-paragraph-gap);
 }
 
 .case-study-block-lede .case-study-lede,

--- a/work/resy-search-ai/index.html
+++ b/work/resy-search-ai/index.html
@@ -40,7 +40,7 @@
       gtag('js', new Date());
       gtag('config', 'G-DEFM9FZ25D');
     </script>
-    <link rel="stylesheet" href="../../assets/css/work-case-study.css?v=20260423-1248" />
+    <link rel="stylesheet" href="../../assets/css/work-case-study.css?v=20260428-0001" />
   </head>
   <body id="top" class="case-study-page work-theme-sommai is-subpage">
     <div class="work-page">
@@ -180,6 +180,22 @@
             </aside>
 
             <article class="work-article-body">
+              <section class="work-article-section case-study-block case-study-block-text case-study-block-preface">
+                <div class="case-study-block-inner">
+                  <p class="case-study-preface">
+                    <em>
+                      <strong>Note:</strong> Resy recently launched an integration with Claude, since this Case Study was
+                      published.
+                      <a
+                        href="https://blog.resy.com/newsroom/resy-restaurants-claude-anthropic/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >Read More on the Resy Blog&nbsp;&rarr;</a>
+                    </em>
+                  </p>
+                </div>
+              </section>
+
               <section class="work-article-section case-study-block case-study-block-text case-study-block-intro-lede">
                 <div class="case-study-block-inner">
                   <p class="case-study-lede">


### PR DESCRIPTION
## Summary

- Adds an italicized preface note to the Resy Search AI case study, linking to Resy's Claude integration announcement.
- Places the note in the main article content well at normal body width, above the larger intro lede.
- Styles the note as a padded, rounded border bubble using the existing case-study border color and adds italic font faces for cleaner rendering.

## Validation

- `./scripts/check-case-study-blocks.sh`
- `./scripts/check-launch-case-studies.sh`
- `git diff --check`

## Preview

Validated against the running local preview at `http://niederbook-air-m4.local:8000/work/resy-search-ai/`.