### PR TITLE
[codex] Play case study videos only in view

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -413,6 +413,7 @@ if (emailLinks.length > 0) {
   if (demoVideos.length > 0) {
     const motionQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
     let reducedMotion = motionQuery.matches;
+    const visibleVideos = new Set();
 
     const syncPausedState = (video) => {
       const frame = video.closest(".case-study-demo-frame, .case-study-sendmoi-video-frame");
@@ -430,6 +431,8 @@ if (emailLinks.length > 0) {
       }
     };
 
+    const canAutoPlay = (video) => !reducedMotion && visibleVideos.has(video);
+
     const playDemo = (video) => {
       const playback = video.play();
       if (playback && typeof playback.catch === "function") {
@@ -446,25 +449,31 @@ if (emailLinks.length > 0) {
       video.pause();
     };
 
-    const observer = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((entry) => {
-          const video = entry.target;
-          if (entry.isIntersecting) {
-            if (!reducedMotion && video.paused) {
-              playDemo(video);
-            }
-          } else {
-            if (!video.paused) {
-              video.pause();
-            }
-          }
-        });
-      },
-      { threshold: 0.25 }
-    );
+    const observer =
+      "IntersectionObserver" in window
+        ? new IntersectionObserver(
+            (entries) => {
+              entries.forEach((entry) => {
+                const video = entry.target;
+                if (entry.isIntersecting) {
+                  visibleVideos.add(video);
+                  if (video.paused && canAutoPlay(video)) {
+                    playDemo(video);
+                  }
+                } else {
+                  visibleVideos.delete(video);
+                  if (!video.paused) {
+                    video.pause();
+                  }
+                }
+              });
+            },
+            { threshold: 0.25 }
+          )
+        : null;
 
     demoVideos.forEach((video) => {
+      video.removeAttribute("autoplay");
       video.addEventListener("error", () => syncUnavailableState(video, true));
       video.addEventListener("loadeddata", () => syncUnavailableState(video, false));
       video.addEventListener("play", () => syncPausedState(video));
@@ -479,7 +488,9 @@ if (emailLinks.length > 0) {
         toggleDemoPlayback(video);
       });
 
-      observer.observe(video);
+      if (observer) {
+        observer.observe(video);
+      }
       syncPausedState(video);
     });
 
@@ -494,7 +505,7 @@ if (emailLinks.length > 0) {
           return;
         }
 
-        if (video.paused && video.currentTime === 0) {
+        if (video.paused && canAutoPlay(video)) {
           playDemo(video);
         }
       });

--- a/scripts/check-aiquota-demo-video.sh
+++ b/scripts/check-aiquota-demo-video.sh
@@ -94,8 +94,8 @@ if "<img" in mobile_block:
 if '../../assets/videos/aiquota-demo-inline.mp4' not in mobile_block:
     fail("AIQuota mobile demo should use the shared inline MP4 asset.")
 
-if "autoplay" not in mobile_block:
-    fail("AIQuota mobile demo should be marked autoplay so phones treat it as motion, not a poster frame.")
+if "autoplay" in mobile_block:
+    fail("AIQuota mobile demo should not autoplay before the shared in-view video behavior starts it.")
 PY
 
 echo "aiquota demo video check passed"

--- a/work/ai-quota/index.html
+++ b/work/ai-quota/index.html
@@ -360,7 +360,6 @@
                               class="case-study-sendmoi-video-player"
                               src="../../assets/videos/aiquota-demo-inline.mp4"
                               poster="../../assets/images/case-studies/ai-quota/article/screenshot.png"
-                              autoplay
                               muted
                               loop
                               playsinline
@@ -382,7 +381,6 @@
                           class="case-study-sendmoi-video-player"
                           src="../../assets/videos/aiquota-demo-inline.mp4"
                           poster="../../assets/images/case-studies/ai-quota/article/screenshot.png"
-                          autoplay
                           muted
                           loop
                           playsinline

--- a/work/resy-discovery/index.html
+++ b/work/resy-discovery/index.html
@@ -396,7 +396,6 @@
                               class="case-study-sendmoi-video-player"
                               src="../../assets/videos/resy-editorial-integration.mp4"
                               poster="../../assets/images/case-studies/resy-discovery/article/resy-editorial-integration-poster.jpg"
-                              autoplay
                               muted
                               loop
                               playsinline

--- a/work/resy-search-ai/index.html
+++ b/work/resy-search-ai/index.html
@@ -350,7 +350,6 @@
                         <video
                           class="case-study-demo-player"
                           src="../../assets/videos/somm-ai-demo-cropped.mp4?v=20260423-0938"
-                          autoplay
                           muted
                           loop
                           playsinline


### PR DESCRIPTION
## Summary

This changes the shared case-study demo video behavior so videos no longer begin playing before they scroll into view.

## Documentation

### Previous behavior

Several live case-study video tags carried the native `autoplay` attribute. Even though the shared `IntersectionObserver` paused videos once JavaScript loaded, the browser could still start fetching or playing the video before the observer took control, especially on page load or while the video was still below the fold.

### New behavior

- The shared `data-case-study-demo-video` controller is now the only path that starts demo video playback.
- Demo videos begin playing when they intersect the viewport threshold and pause when they leave view.
- Reduced-motion preferences still pause autoplay behavior.
- Manual click, tap, Space, and Enter playback controls are preserved.
- The SendMoi draft video already used the shared controller without `autoplay`, so it now follows the same in-view behavior as the live case-study videos.

### Affected pages

- `/work/resy-search-ai/`
- `/work/resy-discovery/`
- `/work/ai-quota/`
- `/drafts/work/sendmoi/`

## Validation

- Ran a focused scan confirming no `data-case-study-demo-video` elements in `work/` or `drafts/work/` carry `autoplay`.
- Browser-checked `/work/resy-search-ai/`: video starts paused below the fold, plays after scrolling into view, and pauses again when scrolled away.
- Browser-checked `/drafts/work/sendmoi/`: same paused, in-view play, offscreen pause behavior.

## Notes

A few existing case-study validation scripts currently fail on older block-name or ordering expectations unrelated to this video playback change, so this PR uses a focused behavioral check for the affected video behavior.