### PR TITLE
[codex] Refine about page career summary

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -180,8 +180,9 @@
                 full product suite from consumer to operator.
               </p>
               <p>
-                My career has moved between brand and product, editorial and engineering, craft and strategy — and I’ve
-                been both an IC and a team lead. That range isn’t incidental. I see design thinking as a discipline that
+                My career has lived in the overlap between product, editorial, brand, and implementation: evolving
+                brands, shaping experiences, making production code changes when the work called for it, and moving
+                between IC and team lead roles. That range isn’t incidental. I see design thinking as a discipline that
                 scales well beyond its traditional domain: applicable to how organizations make decisions, how teams
                 build shared vocabulary, how products earn and lose trust over time.
               </p>


### PR DESCRIPTION
## Summary

Updates the About page career summary to better match John's actual background:

- avoids implying prior roles as a brand designer or engineer
- keeps brand work in scope as something he has evolved and shaped
- describes production code work as implementation support rather than an engineering identity
- preserves the IC/team lead framing from the original paragraph

## Why

The previous sentence said the career moved between "brand and product" and "editorial and engineering," which read a little too much like formal role labels. This revision keeps the range and credibility while making the boundaries more precise.

## Validation

- Reviewed the local diff for `about/index.html`
- Served the site with `make dev-thread`
- Verified `/about/` includes the updated sentence via the local preview