### PR TITLE
[codex] Use git dates for sitemap lastmod

### DIFF
--- a/scripts/update-sitemap.py
+++ b/scripts/update-sitemap.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import html
+import subprocess
 import sys
 import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
@@ -38,6 +39,18 @@ def page_url(path: Path, site_url: str) -> str:
 
 
 def lastmod(path: Path) -> str:
+  relative = path.relative_to(ROOT).as_posix()
+  result = subprocess.run(
+    ["git", "-C", str(ROOT), "log", "-1", "--format=%cs", "--", relative],
+    check=False,
+    capture_output=True,
+    text=True,
+  )
+  if result.returncode == 0:
+    committed_date = result.stdout.strip()
+    if committed_date:
+      return committed_date
+
   timestamp = path.stat().st_mtime
   return datetime.fromtimestamp(timestamp, timezone.utc).date().isoformat()
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,38 +2,38 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://nieder.me/about/</loc>
-    <lastmod>2026-04-30</lastmod>
+    <lastmod>2026-05-01</lastmod>
   </url>
   <url>
     <loc>https://nieder.me/accessibility/</loc>
-    <lastmod>2026-04-30</lastmod>
+    <lastmod>2026-04-29</lastmod>
   </url>
   <url>
     <loc>https://nieder.me/colophon-style-guide/</loc>
-    <lastmod>2026-04-30</lastmod>
+    <lastmod>2026-04-29</lastmod>
   </url>
   <url>
     <loc>https://nieder.me/</loc>
-    <lastmod>2026-04-30</lastmod>
+    <lastmod>2026-04-29</lastmod>
   </url>
   <url>
     <loc>https://nieder.me/privacy/</loc>
-    <lastmod>2026-04-30</lastmod>
+    <lastmod>2026-04-29</lastmod>
   </url>
   <url>
     <loc>https://nieder.me/work/ai-quota/</loc>
-    <lastmod>2026-04-30</lastmod>
+    <lastmod>2026-04-29</lastmod>
   </url>
   <url>
     <loc>https://nieder.me/work/</loc>
-    <lastmod>2026-04-30</lastmod>
+    <lastmod>2026-04-29</lastmod>
   </url>
   <url>
     <loc>https://nieder.me/work/resy-discovery/</loc>
-    <lastmod>2026-04-30</lastmod>
+    <lastmod>2026-04-29</lastmod>
   </url>
   <url>
     <loc>https://nieder.me/work/resy-search-ai/</loc>
-    <lastmod>2026-04-30</lastmod>
+    <lastmod>2026-04-29</lastmod>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary

Fixes the staging deploy failure caused by stale sitemap `<lastmod>` values.

- updates `scripts/update-sitemap.py` to derive each page's `<lastmod>` from the latest git commit touching that page
- keeps the existing filesystem mtime fallback for non-git contexts
- regenerates `sitemap.xml` so the About page reflects the merged copy update

## Why

No URLs were added or removed in PR #110. The deploy failed because `sitemap.xml` also tracks `<lastmod>`, and the previous generator used filesystem modification time. That made the check sensitive to local edits and CI checkout timing instead of actual page history.

Using git commit dates makes the generated sitemap stable across local and GitHub Actions runs while still updating when a page's content changes.

## Validation

- `make check-sitemap`
- `python3 scripts/check-deploy-2026.py`
- `git diff --check`