### PR TITLE
[codex] Fetch full history for deploy workflows

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary

Updates the staging and production deploy workflows to checkout the repository with full git history.

- adds `fetch-depth: 0` to the staging deploy checkout
- adds `fetch-depth: 0` to the production deploy checkout

## Why

PR #111 changed sitemap `<lastmod>` generation to use git commit dates, which is stable locally. The follow-up staging deploy still failed because GitHub Actions checks out a shallow clone by default, so `git log -- <page>` could not see older page history for pages untouched by the latest commit.

Fetching full history makes the deploy environment match local generation and gives the sitemap check the history it needs.

## Validation

- `make check-sitemap`
- `python3 scripts/check-deploy-2026.py`
- `git diff --check`