### PR TITLE
[codex] Correct NYT editorial designer title

### DIFF
--- a/index.html
+++ b/index.html
@@ -273,7 +273,7 @@
                 </article>
 
                 <article class="experience-item">
-                  <h4>Design Lead, Digital News Design</h4>
+                  <h4>Editorial Designer, Digital Design</h4>
                   <p class="experience-company"><a href="https://nytimes.com" target="_blank" rel="noopener noreferrer">The New York Times</a></p>
                   <p class="experience-date">Nov. 2007 - Mar. 2012</p>
                 </article>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -14,7 +14,7 @@
   </url>
   <url>
     <loc>https://nieder.me/</loc>
-    <lastmod>2026-04-29</lastmod>
+    <lastmod>2026-05-01</lastmod>
   </url>
   <url>
     <loc>https://nieder.me/privacy/</loc>
@@ -26,7 +26,7 @@
   </url>
   <url>
     <loc>https://nieder.me/work/</loc>
-    <lastmod>2026-04-29</lastmod>
+    <lastmod>2026-05-01</lastmod>
   </url>
   <url>
     <loc>https://nieder.me/work/resy-discovery/</loc>

--- a/work/index.html
+++ b/work/index.html
@@ -401,7 +401,7 @@
                 </p>
                 <div class="resume-job-body">
                   <h4 class="resume-role resume-role-legacy">
-                    <span>Design Lead, Digital News Design</span>
+                    <span>Editorial Designer, Digital Design</span>
                     <span class="resume-company"><a href="https://nytimes.com" target="_blank" rel="noopener noreferrer">The New York Times</a></span>
                   </h4>
                   <p class="resume-summary">


### PR DESCRIPTION
## Summary

Corrects the older New York Times role title for the 2007-2012 period.

- updates the homepage experience entry from `Design Lead, Digital News Design` to `Editorial Designer, Digital Design`
- updates the matching 2007-2012 role on the full work/resume page
- leaves the later 2012-2014 `Design Lead, Digital News Design` role unchanged
- refreshes `sitemap.xml` for the changed homepage and work page lastmod dates

## Why

The 2007-2012 role was using the wrong title. The correct title is `Editorial Designer, Digital Design`.

## Validation

- Verified the rendered homepage via local preview
- Verified the rendered `/work/` page via local preview
- `make check-sitemap`
- `python3 scripts/check-deploy-2026.py`
- `git diff --check`