### PR TITLE
[codex] Align footer sitemap labels

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -334,17 +334,17 @@
               <h3>Site</h3>
               <ul class="site-footer-links">
                 <li><a href="../">Home</a></li>
-                <li><a href="../work/">Work</a></li>
+                <li><a href="../work/">Work Experience</a></li>
                 <li><a href="../about/" aria-current="page">About &amp; Biography</a></li>
                 <li><a href="../colophon-style-guide/">Colophon &amp; Style Guide</a></li>
               </ul>
             </nav>
 
-            <nav class="site-footer-column site-footer-column-work" aria-label="Work sitemap">
-              <h3>Work</h3>
+            <nav class="site-footer-column site-footer-column-work" aria-label="Case studies sitemap">
+              <h3>Case Studies</h3>
               <ul class="site-footer-links">
-                <li><a href="../work/">Resume &amp; Work</a></li>
                 <li><a href="../work/resy-discovery/">Resy Discovery</a></li>
+                <li><a href="../work/resy-search-ai/">Somm AI</a></li>
                 <li><a href="../work/ai-quota/">AIQuota</a></li>
               </ul>
             </nav>

--- a/accessibility/index.html
+++ b/accessibility/index.html
@@ -268,17 +268,17 @@
               <h3>Site</h3>
               <ul class="site-footer-links">
                 <li><a href="../">Home</a></li>
-                <li><a href="../work/">Work</a></li>
+                <li><a href="../work/">Work Experience</a></li>
                 <li><a href="../about/">About &amp; Biography</a></li>
                 <li><a href="../colophon-style-guide/">Colophon &amp; Style Guide</a></li>
               </ul>
             </nav>
 
-            <nav class="site-footer-column site-footer-column-work" aria-label="Work sitemap">
-              <h3>Work</h3>
+            <nav class="site-footer-column site-footer-column-work" aria-label="Case studies sitemap">
+              <h3>Case Studies</h3>
               <ul class="site-footer-links">
-                <li><a href="../work/">Resume &amp; Work</a></li>
                 <li><a href="../work/resy-discovery/">Resy Discovery</a></li>
+                <li><a href="../work/resy-search-ai/">Somm AI</a></li>
                 <li><a href="../work/ai-quota/">AIQuota</a></li>
               </ul>
             </nav>

--- a/colophon-style-guide/index.html
+++ b/colophon-style-guide/index.html
@@ -726,17 +726,17 @@
               <h3>Site</h3>
               <ul class="site-footer-links">
                 <li><a href="../">Home</a></li>
-                <li><a href="../work/">Work</a></li>
+                <li><a href="../work/">Work Experience</a></li>
                 <li><a href="../about/">About &amp; Biography</a></li>
                 <li><a href="../colophon-style-guide/" aria-current="page">Colophon &amp; Style Guide</a></li>
               </ul>
             </nav>
 
-            <nav class="site-footer-column site-footer-column-work" aria-label="Work sitemap">
-              <h3>Work</h3>
+            <nav class="site-footer-column site-footer-column-work" aria-label="Case studies sitemap">
+              <h3>Case Studies</h3>
               <ul class="site-footer-links">
-                <li><a href="../work/">Resume &amp; Work</a></li>
                 <li><a href="../work/resy-discovery/">Resy Discovery</a></li>
+                <li><a href="../work/resy-search-ai/">Somm AI</a></li>
                 <li><a href="../work/ai-quota/">AIQuota</a></li>
               </ul>
             </nav>

--- a/drafts/work/sendmoi/index.html
+++ b/drafts/work/sendmoi/index.html
@@ -546,16 +546,15 @@
               <h3>Site</h3>
               <ul class="site-footer-links">
                 <li><a href="../../../">Home</a></li>
-                <li><a href="../../../work/">Work</a></li>
+                <li><a href="../../../work/">Work Experience</a></li>
                 <li><a href="../../../about/">About &amp; Biography</a></li>
                 <li><a href="../../../colophon-style-guide/">Colophon &amp; Style Guide</a></li>
               </ul>
             </nav>
 
-            <nav class="site-footer-column site-footer-column-work" aria-label="Work sitemap">
-              <h3>Work</h3>
+            <nav class="site-footer-column site-footer-column-work" aria-label="Case studies sitemap">
+              <h3>Case Studies</h3>
               <ul class="site-footer-links">
-                <li><a href="../../../work/">Resume &amp; Work</a></li>
                 <li><a href="../../../work/resy-discovery/">Resy Discovery</a></li>
                 <li><a href="../../../drafts/work/sendmoi/" aria-current="page">SendMoi</a></li>
                 <li><a href="../../../work/resy-search-ai/">Somm AI</a></li>

--- a/index.html
+++ b/index.html
@@ -489,17 +489,17 @@
               <h3>Site</h3>
               <ul class="site-footer-links">
                 <li><a href="#top" aria-current="page">Home</a></li>
-                <li><a href="work/">Work</a></li>
+                <li><a href="work/">Work Experience</a></li>
                 <li><a href="about/">About &amp; Biography</a></li>
                 <li><a href="colophon-style-guide/">Colophon &amp; Style Guide</a></li>
               </ul>
             </nav>
 
-            <nav class="site-footer-column site-footer-column-work" aria-label="Work sitemap">
-              <h3>Work</h3>
+            <nav class="site-footer-column site-footer-column-work" aria-label="Case studies sitemap">
+              <h3>Case Studies</h3>
               <ul class="site-footer-links">
-                <li><a href="work/">Resume &amp; Work</a></li>
                 <li><a href="work/resy-discovery/">Resy Discovery</a></li>
+                <li><a href="work/resy-search-ai/">Somm AI</a></li>
                 <li><a href="work/ai-quota/">AIQuota</a></li>
               </ul>
             </nav>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -293,17 +293,17 @@
               <h3>Site</h3>
               <ul class="site-footer-links">
                 <li><a href="../">Home</a></li>
-                <li><a href="../work/">Work</a></li>
+                <li><a href="../work/">Work Experience</a></li>
                 <li><a href="../about/">About &amp; Biography</a></li>
                 <li><a href="../colophon-style-guide/">Colophon &amp; Style Guide</a></li>
               </ul>
             </nav>
 
-            <nav class="site-footer-column site-footer-column-work" aria-label="Work sitemap">
-              <h3>Work</h3>
+            <nav class="site-footer-column site-footer-column-work" aria-label="Case studies sitemap">
+              <h3>Case Studies</h3>
               <ul class="site-footer-links">
-                <li><a href="../work/">Resume &amp; Work</a></li>
                 <li><a href="../work/resy-discovery/">Resy Discovery</a></li>
+                <li><a href="../work/resy-search-ai/">Somm AI</a></li>
                 <li><a href="../work/ai-quota/">AIQuota</a></li>
               </ul>
             </nav>

--- a/work/ai-quota/index.html
+++ b/work/ai-quota/index.html
@@ -546,17 +546,17 @@
               <h3>Site</h3>
               <ul class="site-footer-links">
                 <li><a href="../../">Home</a></li>
-                <li><a href="../../work/">Work</a></li>
+                <li><a href="../../work/">Work Experience</a></li>
                 <li><a href="../../about/">About &amp; Biography</a></li>
                 <li><a href="../../colophon-style-guide/">Colophon &amp; Style Guide</a></li>
               </ul>
             </nav>
 
-            <nav class="site-footer-column site-footer-column-work" aria-label="Work sitemap">
-              <h3>Work</h3>
+            <nav class="site-footer-column site-footer-column-work" aria-label="Case studies sitemap">
+              <h3>Case Studies</h3>
               <ul class="site-footer-links">
-                <li><a href="../../work/">Resume &amp; Work</a></li>
                 <li><a href="../../work/resy-discovery/">Resy Discovery</a></li>
+                <li><a href="../../work/resy-search-ai/">Somm AI</a></li>
                 <li><a href="../../work/ai-quota/" aria-current="page">AIQuota</a></li>
               </ul>
             </nav>

--- a/work/index.html
+++ b/work/index.html
@@ -633,17 +633,17 @@
               <h3>Site</h3>
               <ul class="site-footer-links">
                 <li><a href="../">Home</a></li>
-                <li><a href="../work/">Work</a></li>
+                <li><a href="../work/" aria-current="page">Work Experience</a></li>
                 <li><a href="../about/">About &amp; Biography</a></li>
                 <li><a href="../colophon-style-guide/">Colophon &amp; Style Guide</a></li>
               </ul>
             </nav>
 
-            <nav class="site-footer-column site-footer-column-work" aria-label="Work sitemap">
-              <h3>Work</h3>
+            <nav class="site-footer-column site-footer-column-work" aria-label="Case studies sitemap">
+              <h3>Case Studies</h3>
               <ul class="site-footer-links">
-                <li><a href="../work/" aria-current="page">Resume &amp; Work</a></li>
                 <li><a href="../work/resy-discovery/">Resy Discovery</a></li>
+                <li><a href="../work/resy-search-ai/">Somm AI</a></li>
                 <li><a href="../work/ai-quota/">AIQuota</a></li>
               </ul>
             </nav>

--- a/work/resy-discovery/index.html
+++ b/work/resy-discovery/index.html
@@ -652,17 +652,17 @@
               <h3>Site</h3>
               <ul class="site-footer-links">
                 <li><a href="../../">Home</a></li>
-                <li><a href="../../work/">Work</a></li>
+                <li><a href="../../work/">Work Experience</a></li>
                 <li><a href="../../about/">About &amp; Biography</a></li>
                 <li><a href="../../colophon-style-guide/">Colophon &amp; Style Guide</a></li>
               </ul>
             </nav>
 
-            <nav class="site-footer-column site-footer-column-work" aria-label="Work sitemap">
-              <h3>Work</h3>
+            <nav class="site-footer-column site-footer-column-work" aria-label="Case studies sitemap">
+              <h3>Case Studies</h3>
               <ul class="site-footer-links">
-                <li><a href="../../work/">Resume &amp; Work</a></li>
                 <li><a href="../../work/resy-discovery/" aria-current="page">Resy Discovery</a></li>
+                <li><a href="../../work/resy-search-ai/">Somm AI</a></li>
                 <li><a href="../../work/ai-quota/">AIQuota</a></li>
               </ul>
             </nav>

--- a/work/resy-search-ai/index.html
+++ b/work/resy-search-ai/index.html
@@ -498,16 +498,15 @@
               <h3>Site</h3>
               <ul class="site-footer-links">
                 <li><a href="../../">Home</a></li>
-                <li><a href="../../work/">Work</a></li>
+                <li><a href="../../work/">Work Experience</a></li>
                 <li><a href="../../about/">About &amp; Biography</a></li>
                 <li><a href="../../colophon-style-guide/">Colophon &amp; Style Guide</a></li>
               </ul>
             </nav>
 
-            <nav class="site-footer-column site-footer-column-work" aria-label="Work sitemap">
-              <h3>Work</h3>
+            <nav class="site-footer-column site-footer-column-work" aria-label="Case studies sitemap">
+              <h3>Case Studies</h3>
               <ul class="site-footer-links">
-                <li><a href="../../work/">Resume &amp; Work</a></li>
                 <li><a href="../../work/resy-discovery/">Resy Discovery</a></li>
                 <li><a href="../../work/resy-search-ai/" aria-current="page">Somm AI</a></li>
                 <li><a href="../../work/ai-quota/">AIQuota</a></li>


### PR DESCRIPTION
## Summary
- Update the footer Site column so the `/work/` link uses the actual page title, `Work Experience`.
- Rename the right footer column from `Work` to `Case Studies` and update its accessible label.
- Remove the duplicate `/work/` footer entry from the case-study column and add the missing `Somm AI` case-study link.

## Why
The footer previously had two links pointing to `/work/`, one in `Site` and one in the `Work` column. This made the sitemap feel redundant and blurred the distinction between the top-level work page and individual case studies.

## Verification
- `make check-sitemap`
- `git diff --check`
- Live preview verified at `http://localhost:8000/`