### PR TITLE
[codex] Refresh sitemap before staging deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,9 @@ jobs:
           lightningcss --minify --sourcemap assets/css/styleguide.css -o assets/css/styleguide.css
           terser assets/js/main.js -o assets/js/main.js --sourcemap "url='main.js.map'" --compress --mangle
 
+      - name: Refresh sitemap
+        run: ./scripts/update-sitemap.py
+
       - name: Set up SSH
         run: |
           install -m 700 -d ~/.ssh

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,38 +2,38 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://nieder.me/about/</loc>
-    <lastmod>2026-05-01</lastmod>
+    <lastmod>2026-05-04</lastmod>
   </url>
   <url>
     <loc>https://nieder.me/accessibility/</loc>
-    <lastmod>2026-04-29</lastmod>
+    <lastmod>2026-05-04</lastmod>
   </url>
   <url>
     <loc>https://nieder.me/colophon-style-guide/</loc>
-    <lastmod>2026-04-29</lastmod>
+    <lastmod>2026-05-04</lastmod>
   </url>
   <url>
     <loc>https://nieder.me/</loc>
-    <lastmod>2026-05-01</lastmod>
+    <lastmod>2026-05-04</lastmod>
   </url>
   <url>
     <loc>https://nieder.me/privacy/</loc>
-    <lastmod>2026-04-29</lastmod>
+    <lastmod>2026-05-04</lastmod>
   </url>
   <url>
     <loc>https://nieder.me/work/ai-quota/</loc>
-    <lastmod>2026-04-29</lastmod>
+    <lastmod>2026-05-04</lastmod>
   </url>
   <url>
     <loc>https://nieder.me/work/</loc>
-    <lastmod>2026-05-01</lastmod>
+    <lastmod>2026-05-04</lastmod>
   </url>
   <url>
     <loc>https://nieder.me/work/resy-discovery/</loc>
-    <lastmod>2026-04-29</lastmod>
+    <lastmod>2026-05-04</lastmod>
   </url>
   <url>
     <loc>https://nieder.me/work/resy-search-ai/</loc>
-    <lastmod>2026-04-29</lastmod>
+    <lastmod>2026-05-04</lastmod>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary
- Add a `Refresh sitemap` step to the staging deploy workflow before SSH setup and deploy.
- Update `sitemap.xml` so the merged footer-label pages have the correct `lastmod` dates.

## Why
The staging deploy failed because `scripts/deploy-2026.sh` runs `scripts/update-sitemap.py --check`, and `sitemap.xml` became stale after the merge commit changed the latest committed dates for the edited HTML pages.

This is the repeat failure mode we saw before: `make check-sitemap` can pass before committing, but the generated sitemap can become stale once the HTML changes exist in git history. Regenerating the sitemap inside the GitHub Actions workspace before deploy makes the staging job resilient to that commit-time `lastmod` change.

## Verification
- `make check-sitemap`
- `python3 scripts/check-deploy-2026.py`
- `git diff --check`