### PR TITLE
[codex] Use full work page label

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -334,7 +334,7 @@
               <h3>Site</h3>
               <ul class="site-footer-links">
                 <li><a href="../">Home</a></li>
-                <li><a href="../work/">Work Experience</a></li>
+                <li><a href="../work/">Work Experience &amp; Resume</a></li>
                 <li><a href="../about/" aria-current="page">About &amp; Biography</a></li>
                 <li><a href="../colophon-style-guide/">Colophon &amp; Style Guide</a></li>
               </ul>

--- a/accessibility/index.html
+++ b/accessibility/index.html
@@ -268,7 +268,7 @@
               <h3>Site</h3>
               <ul class="site-footer-links">
                 <li><a href="../">Home</a></li>
-                <li><a href="../work/">Work Experience</a></li>
+                <li><a href="../work/">Work Experience &amp; Resume</a></li>
                 <li><a href="../about/">About &amp; Biography</a></li>
                 <li><a href="../colophon-style-guide/">Colophon &amp; Style Guide</a></li>
               </ul>

--- a/colophon-style-guide/index.html
+++ b/colophon-style-guide/index.html
@@ -726,7 +726,7 @@
               <h3>Site</h3>
               <ul class="site-footer-links">
                 <li><a href="../">Home</a></li>
-                <li><a href="../work/">Work Experience</a></li>
+                <li><a href="../work/">Work Experience &amp; Resume</a></li>
                 <li><a href="../about/">About &amp; Biography</a></li>
                 <li><a href="../colophon-style-guide/" aria-current="page">Colophon &amp; Style Guide</a></li>
               </ul>

--- a/drafts/work/sendmoi/index.html
+++ b/drafts/work/sendmoi/index.html
@@ -546,7 +546,7 @@
               <h3>Site</h3>
               <ul class="site-footer-links">
                 <li><a href="../../../">Home</a></li>
-                <li><a href="../../../work/">Work Experience</a></li>
+                <li><a href="../../../work/">Work Experience &amp; Resume</a></li>
                 <li><a href="../../../about/">About &amp; Biography</a></li>
                 <li><a href="../../../colophon-style-guide/">Colophon &amp; Style Guide</a></li>
               </ul>

--- a/index.html
+++ b/index.html
@@ -489,7 +489,7 @@
               <h3>Site</h3>
               <ul class="site-footer-links">
                 <li><a href="#top" aria-current="page">Home</a></li>
-                <li><a href="work/">Work Experience</a></li>
+                <li><a href="work/">Work Experience &amp; Resume</a></li>
                 <li><a href="about/">About &amp; Biography</a></li>
                 <li><a href="colophon-style-guide/">Colophon &amp; Style Guide</a></li>
               </ul>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -293,7 +293,7 @@
               <h3>Site</h3>
               <ul class="site-footer-links">
                 <li><a href="../">Home</a></li>
-                <li><a href="../work/">Work Experience</a></li>
+                <li><a href="../work/">Work Experience &amp; Resume</a></li>
                 <li><a href="../about/">About &amp; Biography</a></li>
                 <li><a href="../colophon-style-guide/">Colophon &amp; Style Guide</a></li>
               </ul>

--- a/work/ai-quota/index.html
+++ b/work/ai-quota/index.html
@@ -546,7 +546,7 @@
               <h3>Site</h3>
               <ul class="site-footer-links">
                 <li><a href="../../">Home</a></li>
-                <li><a href="../../work/">Work Experience</a></li>
+                <li><a href="../../work/">Work Experience &amp; Resume</a></li>
                 <li><a href="../../about/">About &amp; Biography</a></li>
                 <li><a href="../../colophon-style-guide/">Colophon &amp; Style Guide</a></li>
               </ul>

--- a/work/index.html
+++ b/work/index.html
@@ -8,7 +8,7 @@
     <link rel="icon" href="/favicon.ico" sizes="any" />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-    <title>Work | John Niedermeyer</title>
+    <title>Work Experience &amp; Resume | John Niedermeyer</title>
     <meta
       name="description"
       content="Full work experience and resume for John Niedermeyer, with selected case studies across Resy and AIQuota."
@@ -633,7 +633,7 @@
               <h3>Site</h3>
               <ul class="site-footer-links">
                 <li><a href="../">Home</a></li>
-                <li><a href="../work/" aria-current="page">Work Experience</a></li>
+                <li><a href="../work/" aria-current="page">Work Experience &amp; Resume</a></li>
                 <li><a href="../about/">About &amp; Biography</a></li>
                 <li><a href="../colophon-style-guide/">Colophon &amp; Style Guide</a></li>
               </ul>

--- a/work/resy-discovery/index.html
+++ b/work/resy-discovery/index.html
@@ -652,7 +652,7 @@
               <h3>Site</h3>
               <ul class="site-footer-links">
                 <li><a href="../../">Home</a></li>
-                <li><a href="../../work/">Work Experience</a></li>
+                <li><a href="../../work/">Work Experience &amp; Resume</a></li>
                 <li><a href="../../about/">About &amp; Biography</a></li>
                 <li><a href="../../colophon-style-guide/">Colophon &amp; Style Guide</a></li>
               </ul>

--- a/work/resy-search-ai/index.html
+++ b/work/resy-search-ai/index.html
@@ -498,7 +498,7 @@
               <h3>Site</h3>
               <ul class="site-footer-links">
                 <li><a href="../../">Home</a></li>
-                <li><a href="../../work/">Work Experience</a></li>
+                <li><a href="../../work/">Work Experience &amp; Resume</a></li>
                 <li><a href="../../about/">About &amp; Biography</a></li>
                 <li><a href="../../colophon-style-guide/">Colophon &amp; Style Guide</a></li>
               </ul>


### PR DESCRIPTION
## Summary
- Update footer links to `/work/` so the user-facing label is consistently `Work Experience & Resume`.
- Update the `/work/` browser title to `Work Experience & Resume | John Niedermeyer`.
- Keep the URL slug as `/work/` and preserve the existing visual hero treatment: `Work Experience` plus the red `& Resume` line.

## Why
The site had a few labels for the same destination: the nav popover used `Work Experience & Resume`, the footer used `Work Experience`, and the title tag still used `Work`. This PR keeps `/work/` as the clean slug while making the visible destination label consistent.

## Verification
- `make check-sitemap`
- `python3 scripts/check-deploy-2026.py`
- `git diff --check`
- Local live preview at `http://localhost:8000/work/` confirmed the title tag, hero, and footer labels.