### PR TITLE
Let resume links wrap naturally

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1173,9 +1173,6 @@ body.grid-hidden .grid-overlay > span {
 
   .resume-link:hover {
     color: var(--accent);
-  }
-
-  .resume-link:hover .resume-link-line {
     border-bottom-color: rgba(255, 69, 58, 0.65);
   }
 }
@@ -1199,31 +1196,21 @@ body.grid-hidden .grid-overlay > span {
 }
 
 .resume-link {
-  display: inline-flex;
-  flex-direction: column;
-  align-items: flex-start;
+  display: inline;
   color: var(--accent);
   font-size: 18px;
   font-weight: 700;
   text-decoration: none;
   line-height: 1.2;
-  gap: 0;
-  transition: color 0.2s ease;
-}
-
-.resume-link-line {
-  display: block;
-  width: fit-content;
-  white-space: nowrap;
+  text-wrap: pretty;
   border-bottom: 1px solid transparent;
-  transition: border-color 0.18s ease;
+  transition:
+    color 0.2s ease,
+    border-color 0.18s ease;
 }
 
 .resume-link:focus-visible {
   color: var(--accent);
-}
-
-.resume-link:focus-visible .resume-link-line {
   border-bottom-color: rgba(255, 69, 58, 0.65);
 }
 
@@ -3039,34 +3026,20 @@ body.grid-hidden .grid-overlay > span {
   }
 
   .resume-link {
-    display: inline-flex;
-    flex-direction: column;
-    align-items: flex-start;
+    display: inline;
     white-space: normal;
-    border-bottom: 0;
-    transition: color 0.2s ease;
-  }
-
-  .resume-link-line {
-    display: block;
-    width: fit-content;
-    white-space: nowrap;
     border-bottom: 1px solid transparent;
+    text-wrap: pretty;
+    transition:
+      color 0.2s ease,
+      border-color 0.18s ease;
   }
 
   .resume-link:focus-visible {
-    border-bottom-color: transparent;
-  }
-
-  .resume-link:focus-visible .resume-link-line {
     border-bottom-color: rgba(255, 69, 58, 0.65);
   }
 
   .resume-link:hover {
-    border-bottom-color: transparent;
-  }
-
-  .resume-link:hover .resume-link-line {
     border-bottom-color: rgba(255, 69, 58, 0.65);
   }
 

--- a/index.html
+++ b/index.html
@@ -220,10 +220,7 @@
             <header class="experience-heading">
               <h3>Work Experience</h3>
               <p class="resume-link-wrap">
-                <a class="resume-link" href="work/">
-                  <span class="resume-link-line">Full Work Experience</span>
-                  <span class="resume-link-line">&amp; Resume →</span>
-                </a>
+                <a class="resume-link" href="work/">Full Work Experience &amp; Resume →</a>
               </p>
             </header>
 
@@ -440,10 +437,7 @@
                 I value a way of working that is clear, collaborative, and steady from first ideas through launch.
               </p>
               <p class="resume-link-wrap">
-                <a class="resume-link" href="about/">
-                  <span class="resume-link-line">More About Me</span>
-                  <span class="resume-link-line">&amp; How I work &rarr;</span>
-                </a>
+                <a class="resume-link" href="about/">More About Me &amp; How I work &rarr;</a>
               </p>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- remove artificial per-line spans from resume/about CTA links
- let the link text wrap naturally with CSS text-wrap: pretty
- simplify hover/focus underline styles now that the links are inline

## Checks
- git diff --check
- make check-sitemap
- python3 scripts/check-deploy-2026.py
- Playwright render check at 646x407 confirmed both resume links are inline with text-wrap: pretty