### PR TITLE
Update handoff and social metadata docs

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,34 +1,50 @@
 # Handoff
 
-## Branch
-- `codex/sendmoi-draft-edit`
+## Current State
 
-## Current Focus
-- SendMoi case study has been promoted from draft to the public work surface at `work/sendmoi/`.
+- SendMoi is published at `work/sendmoi/` and live in production at `https://nieder.me/work/sendmoi/`.
+- Sitewide social metadata is in place for every HTML page in the repo.
+- Case studies have dedicated `1200x630` social share images in `assets/images/og/`.
+- Non-case-study, utility, policy, and redirect pages use the global fallback image `assets/images/og/og-image-1200x630.png`.
 - The `drafts/` framework remains for future unpublished case studies and stays excluded from deploy.
-- Current local preview convention: `make dev-live-thread`, then review `/work/sendmoi/`.
 
-## What Changed
-- Published the SendMoi case study from `drafts/work/sendmoi/` to `work/sendmoi/`.
-- Updated homepage, work index, case-study recirculation cards, and case-study footer links to point to the live SendMoi page.
-- Added SendMoi download cards with iOS and Mac App Store badges.
-- Added the Codex and Claude Code right-rail image block using light/dark SVG assets.
-- Updated SendMoi hero and promo art.
-- Updated validation scripts so SendMoi is treated as a live case study.
-- Updated README and draft documentation to keep the drafts workflow available for future work.
+## Recent PRs
+
+- `#118` / `371baaf`: published the SendMoi case study.
+- `#119` / `d79c3b9`: fixed SendMoi heading capitalization.
+- `#120` / `1da89f4`: added sitewide canonical, Open Graph, and Twitter/X metadata plus social metadata checks.
+
+## Current Workflow
+
+- Do not develop on `main`; use a dedicated `codex/*` branch.
+- Use `make dev-live-thread` for the shared local preview.
+- Thread preview URL convention: `http://Niederbook-Air-M4.local:8001/`.
+- Draft case studies should start under `drafts/work/<slug>/`.
+- Promote drafts only when ready by moving them into `work/<slug>/` and updating public links, validation scripts, sitemap, and social metadata.
 
 ## Verification
-- Run the full local check set before merging:
-  - `git diff --check`
-  - `bash scripts/check-launch-case-studies.sh`
-  - `bash scripts/check-case-study-rail.sh`
-  - `bash scripts/check-case-study-blocks.sh`
-  - `bash scripts/check-policy-pages.sh`
-  - `bash scripts/check-ga4-analytics.sh`
-  - `bash scripts/check-image-organization.sh`
-  - `python3 scripts/check-deploy-2026.py`
-  - `python3 scripts/update-sitemap.py --check`
+
+Run this set before merging rendered site changes:
+
+- `make check-social`
+- `python3 scripts/update-sitemap.py --check`
+- `git diff --check`
+- `bash scripts/check-launch-case-studies.sh`
+- `bash scripts/check-case-study-rail.sh`
+- `bash scripts/check-case-study-blocks.sh`
+- `bash scripts/check-policy-pages.sh`
+- `bash scripts/check-ga4-analytics.sh`
+- `bash scripts/check-image-organization.sh`
+- `python3 scripts/check-deploy-2026.py`
+
+## Deploy Notes
+
+- Merging to `main` triggers staging deploy to `https://nieder.me/2026`.
+- Production deploy is explicit via the "Deploy Production" GitHub Actions workflow or `make deploy-prod`.
+- Production is currently verified through merge commit `1da89f4`.
 
 ## Notes
-- `drafts/` should not be linked from public pages.
-- When creating the next unpublished case study, start under `drafts/work/<slug>/` and promote it only when ready.
+
+- Public pages should not link into `drafts/`.
+- New public HTML pages should not ship without canonical, Open Graph, and Twitter/X card metadata.
+- New case studies should get a page-specific social share image in `assets/images/og/`.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Core project files:
 - `assets/css/work-case-study.css` work index and case-study styles
 - `assets/css/styleguide.css` colophon and style-guide styles
 - `assets/js/main.js` shared client-side behavior
+- `assets/images/og/` sitewide and page-specific social share images
 - `assets/` images, icons, fonts, and video
 - `scripts/` local helpers for deploy, verification, and GitHub issue creation
 - `Makefile` preview, live-reload, and helper commands
@@ -184,11 +185,15 @@ make site-url-prod
 
 Every public HTML page should include a canonical URL, Open Graph metadata, and Twitter/X card metadata. Case studies should use the best available case-study promo image as the social image. Utility, policy, redirect, and index pages should fall back to `assets/images/og/og-image-1200x630.png`.
 
+Case-study social images live in `assets/images/og/` and should be exported at `1200x630`. Keep the declared `og:image:width`, `og:image:height`, and `og:image:type` in sync with the real file. The checker verifies this, plus the presence of canonical URLs, OG tags, Twitter/X tags, local image files, and matching OG/Twitter image URLs.
+
 Run this before publishing metadata-sensitive changes:
 
 ```bash
 make check-social
 ```
+
+When promoting a draft page into the public site, add or update its social metadata at the same time.
 
 ## Releases
 

--- a/drafts/README.md
+++ b/drafts/README.md
@@ -8,6 +8,7 @@ Use `drafts/work/<slug>/` for unpublished case studies that need local preview a
 
 - Move finished case studies into `work/<slug>/`.
 - Update public promos, recirculation links, footers, validation scripts, and `sitemap.xml`.
+- Add page-specific social metadata and a `1200x630` share image under `assets/images/og/`.
 - Keep `drafts/` in place for future unpublished work.
 
 The deploy script does not copy this directory, and public pages should not link here.


### PR DESCRIPTION
## Summary
- Refresh HANDOFF.md with the shipped SendMoi/social metadata state, recent PRs, and current verification/deploy notes
- Document assets/images/og/ and the 1200x630 social image rule in README.md
- Add social metadata and share-image requirements to the draft promotion checklist

## Checks
- make check-social
- git diff --check

## Deploy
- Docs-only PR; not merged yet, so no deploy has been triggered from this wrap-up change.
