### PR TITLE
[codex] Polish footer case study links

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -70,7 +70,7 @@
       gtag('js', new Date());
       gtag('config', 'G-DEFM9FZ25D');
     </script>
-    <link rel="stylesheet" href="../assets/css/work-case-study.css" />
+    <link rel="stylesheet" href="../assets/css/work-case-study.css?v=20260509-footer-links" />
   </head>
   <body id="top" class="policy-page is-subpage">
     <div class="work-page">
@@ -370,9 +370,10 @@
             <nav class="site-footer-column site-footer-column-work" aria-label="Case studies sitemap">
               <h3>Case Studies</h3>
               <ul class="site-footer-links">
-                <li><a href="../work/resy-discovery/">Resy Discovery</a></li>
-                <li><a href="../work/resy-search-ai/">Somm AI</a></li>
-                <li><a href="../work/ai-quota/">AIQuota</a></li>
+                <li><a href="../work/resy-discovery/">Resy App Discovery</a></li>
+                <li><a href="../work/ai-quota/">AIQuota for macOS</a></li>
+                <li><a href="../work/resy-search-ai/">Resy AI Exploration</a></li>
+                <li><a href="../work/sendmoi/">SendMoi for iOS &amp; macOS</a></li>
               </ul>
             </nav>
           </div>

--- a/accessibility/index.html
+++ b/accessibility/index.html
@@ -70,7 +70,7 @@
       gtag('js', new Date());
       gtag('config', 'G-DEFM9FZ25D');
     </script>
-    <link rel="stylesheet" href="../assets/css/work-case-study.css" />
+    <link rel="stylesheet" href="../assets/css/work-case-study.css?v=20260509-footer-links" />
   </head>
   <body id="top" class="policy-page is-subpage">
     <div class="work-page">
@@ -304,9 +304,10 @@
             <nav class="site-footer-column site-footer-column-work" aria-label="Case studies sitemap">
               <h3>Case Studies</h3>
               <ul class="site-footer-links">
-                <li><a href="../work/resy-discovery/">Resy Discovery</a></li>
-                <li><a href="../work/resy-search-ai/">Somm AI</a></li>
-                <li><a href="../work/ai-quota/">AIQuota</a></li>
+                <li><a href="../work/resy-discovery/">Resy App Discovery</a></li>
+                <li><a href="../work/ai-quota/">AIQuota for macOS</a></li>
+                <li><a href="../work/resy-search-ai/">Resy AI Exploration</a></li>
+                <li><a href="../work/sendmoi/">SendMoi for iOS &amp; macOS</a></li>
               </ul>
             </nav>
           </div>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -20,7 +20,8 @@
   --grid-overlay-fill: rgba(255, 255, 255, 0.08);
   --footer-meta: #8e8f98;
   --footer-heading: #8e8f98;
-  --footer-link-underline: rgba(255, 255, 255, 0.92);
+  --footer-link-underline: rgba(255, 255, 255, 0.65);
+  --footer-link-underline-hover: rgba(255, 255, 255, 1);
   --about-surface: #111111;
   --about-shadow: rgba(0, 0, 0, 0.32);
   --colophon-surface: #121212;
@@ -56,7 +57,8 @@
   --grid-overlay-fill: rgba(18, 18, 18, 0.08);
   --footer-meta: #5f6268;
   --footer-heading: #5f6268;
-  --footer-link-underline: rgba(18, 18, 18, 0.88);
+  --footer-link-underline: rgba(18, 18, 18, 0.65);
+  --footer-link-underline-hover: rgba(18, 18, 18, 1);
   --about-surface: #f3eee5;
   --about-shadow: rgba(18, 18, 18, 0.1);
   --colophon-surface: #f5efe5;
@@ -1554,6 +1556,7 @@ body.grid-hidden .grid-overlay > span {
 .site-footer-utility-links a {
   color: inherit;
   text-decoration: none;
+  border-bottom: 1px solid color-mix(in srgb, currentColor 65%, transparent);
   transition: color 0.18s ease;
 }
 
@@ -1565,10 +1568,10 @@ body.grid-hidden .grid-overlay > span {
 .site-footer-utility-links a:hover,
 .site-footer-utility-links a:focus-visible {
   color: var(--fg);
+  border-bottom-color: color-mix(in srgb, currentColor 65%, transparent);
 }
 
 .site-footer-utility-links a:focus-visible {
-  text-decoration: underline;
   text-underline-offset: 0.14em;
 }
 
@@ -1597,18 +1600,6 @@ body.grid-hidden .grid-overlay > span {
   margin: 0;
 }
 
-@media (min-width: 1101px) {
-  .site-footer-column-work .site-footer-links {
-    display: grid;
-    grid-template-rows: repeat(3, auto);
-    grid-auto-flow: column;
-    column-gap: 36px;
-    row-gap: 8px;
-    justify-content: start;
-    width: max-content;
-  }
-}
-
 .site-footer-links a {
   position: relative;
   display: inline-block;
@@ -1617,6 +1608,8 @@ body.grid-hidden .grid-overlay > span {
   line-height: 1.35;
   font-weight: 400;
   text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: color 0.18s ease, border-bottom-color 0.18s ease;
 }
 
 .site-footer-links a:visited {
@@ -1631,32 +1624,10 @@ body.grid-hidden .grid-overlay > span {
   color: var(--fg);
 }
 
-.site-footer-links a::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  bottom: -2px;
-  width: 100%;
-  height: 1px;
-  background: var(--footer-link-underline);
-  transform: scaleX(0);
-  transform-origin: left center;
-  transition: transform 0.22s ease;
-}
-
 .site-footer-links a:hover,
 .site-footer-links a:focus-visible {
   color: var(--fg);
-}
-
-.site-footer-links a:hover::after,
-.site-footer-links a:focus-visible::after {
-  transform: scaleX(1);
-}
-
-.site-footer-links a[aria-current="page"]::after {
-  opacity: 0.45;
-  transform: scaleX(1);
+  border-bottom-color: var(--footer-link-underline-hover);
 }
 
 .site-footer-social {

--- a/assets/css/work-case-study.css
+++ b/assets/css/work-case-study.css
@@ -72,7 +72,8 @@
   --figure-caption: rgba(235, 235, 245, 0.74);
   --footer-meta: #8e8f98;
   --footer-heading: #8e8f98;
-  --footer-link-underline: rgba(255, 255, 255, 0.92);
+  --footer-link-underline: rgba(255, 255, 255, 0.65);
+  --footer-link-underline-hover: rgba(255, 255, 255, 1);
   --text-link-underline: rgba(255, 69, 58, 0.58);
   --case-study-stage-bg: linear-gradient(180deg, #1a1b1f 0%, #101114 100%);
   --case-study-stage-border: rgba(255, 255, 255, 0.08);
@@ -123,7 +124,8 @@
   --figure-caption: rgba(18, 18, 18, 0.7);
   --footer-meta: #5f6268;
   --footer-heading: #5f6268;
-  --footer-link-underline: rgba(18, 18, 18, 0.88);
+  --footer-link-underline: rgba(18, 18, 18, 0.65);
+  --footer-link-underline-hover: rgba(18, 18, 18, 1);
   --case-study-stage-bg: linear-gradient(180deg, #191a1e 0%, #101114 100%);
   --case-study-stage-border: rgba(0, 0, 0, 0.1);
   --logo-filter: brightness(0) saturate(100%);
@@ -3192,6 +3194,7 @@ body.grid-hidden .work-grid-overlay > span {
 .site-footer-utility-links a {
   color: inherit;
   text-decoration: none;
+  border-bottom: 1px solid color-mix(in srgb, currentColor 65%, transparent);
   transition: color 0.18s ease;
 }
 
@@ -3203,10 +3206,10 @@ body.grid-hidden .work-grid-overlay > span {
 .site-footer-utility-links a:hover,
 .site-footer-utility-links a:focus-visible {
   color: var(--fg);
+  border-bottom-color: color-mix(in srgb, currentColor 65%, transparent);
 }
 
 .site-footer-utility-links a:focus-visible {
-  text-decoration: underline;
   text-underline-offset: 0.14em;
 }
 
@@ -3231,18 +3234,6 @@ body.grid-hidden .work-grid-overlay > span {
   margin: 0;
 }
 
-@media (min-width: 1101px) {
-  .site-footer-column-work .site-footer-links {
-    display: grid;
-    grid-template-rows: repeat(3, auto);
-    grid-auto-flow: column;
-    column-gap: 36px;
-    row-gap: 8px;
-    justify-content: start;
-    width: max-content;
-  }
-}
-
 .site-footer-links a {
   position: relative;
   display: inline-block;
@@ -3251,6 +3242,8 @@ body.grid-hidden .work-grid-overlay > span {
   line-height: 1.35;
   font-weight: 400;
   text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: color 0.18s ease, border-bottom-color 0.18s ease;
 }
 
 .site-footer-links a:visited {
@@ -3265,32 +3258,10 @@ body.grid-hidden .work-grid-overlay > span {
   color: var(--label-secondary);
 }
 
-.site-footer-links a::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  bottom: -2px;
-  width: 100%;
-  height: 1px;
-  background: var(--footer-link-underline);
-  transform: scaleX(0);
-  transform-origin: left center;
-  transition: transform 0.22s ease;
-}
-
 .site-footer-links a:hover,
 .site-footer-links a:focus-visible {
   color: var(--fg);
-}
-
-.site-footer-links a:hover::after,
-.site-footer-links a:focus-visible::after {
-  transform: scaleX(1);
-}
-
-.site-footer-links a[aria-current="page"]::after {
-  opacity: 0;
-  transform: scaleX(0);
+  border-bottom-color: var(--footer-link-underline-hover);
 }
 
 .site-footer-social {

--- a/colophon-style-guide/index.html
+++ b/colophon-style-guide/index.html
@@ -70,7 +70,7 @@
       gtag('js', new Date());
       gtag('config', 'G-DEFM9FZ25D');
     </script>
-    <link rel="stylesheet" href="../assets/css/work-case-study.css?v=20260326-004" />
+    <link rel="stylesheet" href="../assets/css/work-case-study.css?v=20260509-footer-links" />
     <link rel="stylesheet" href="../assets/css/styleguide.css?v=20260314-001" />
   </head>
   <body id="top" class="policy-page is-subpage">
@@ -762,9 +762,10 @@
             <nav class="site-footer-column site-footer-column-work" aria-label="Case studies sitemap">
               <h3>Case Studies</h3>
               <ul class="site-footer-links">
-                <li><a href="../work/resy-discovery/">Resy Discovery</a></li>
-                <li><a href="../work/resy-search-ai/">Somm AI</a></li>
-                <li><a href="../work/ai-quota/">AIQuota</a></li>
+                <li><a href="../work/resy-discovery/">Resy App Discovery</a></li>
+                <li><a href="../work/ai-quota/">AIQuota for macOS</a></li>
+                <li><a href="../work/resy-search-ai/">Resy AI Exploration</a></li>
+                <li><a href="../work/sendmoi/">SendMoi for iOS &amp; macOS</a></li>
               </ul>
             </nav>
           </div>

--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
       gtag('js', new Date());
       gtag('config', 'G-DEFM9FZ25D');
     </script>
-    <link rel="stylesheet" href="assets/css/styles.css" />
+    <link rel="stylesheet" href="assets/css/styles.css?v=20260509-footer-links" />
   </head>
   <body id="top">
     <div class="page">
@@ -498,9 +498,10 @@
             <nav class="site-footer-column site-footer-column-work" aria-label="Case studies sitemap">
               <h3>Case Studies</h3>
               <ul class="site-footer-links">
-                <li><a href="work/resy-discovery/">Resy Discovery</a></li>
-                <li><a href="work/resy-search-ai/">Somm AI</a></li>
-                <li><a href="work/ai-quota/">AIQuota</a></li>
+                <li><a href="work/resy-discovery/">Resy App Discovery</a></li>
+                <li><a href="work/ai-quota/">AIQuota for macOS</a></li>
+                <li><a href="work/resy-search-ai/">Resy AI Exploration</a></li>
+                <li><a href="work/sendmoi/">SendMoi for iOS &amp; macOS</a></li>
               </ul>
             </nav>
 

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -70,7 +70,7 @@
       gtag('js', new Date());
       gtag('config', 'G-DEFM9FZ25D');
     </script>
-    <link rel="stylesheet" href="../assets/css/work-case-study.css" />
+    <link rel="stylesheet" href="../assets/css/work-case-study.css?v=20260509-footer-links" />
   </head>
   <body id="top" class="policy-page is-subpage">
     <div class="work-page">
@@ -329,9 +329,10 @@
             <nav class="site-footer-column site-footer-column-work" aria-label="Case studies sitemap">
               <h3>Case Studies</h3>
               <ul class="site-footer-links">
-                <li><a href="../work/resy-discovery/">Resy Discovery</a></li>
-                <li><a href="../work/resy-search-ai/">Somm AI</a></li>
-                <li><a href="../work/ai-quota/">AIQuota</a></li>
+                <li><a href="../work/resy-discovery/">Resy App Discovery</a></li>
+                <li><a href="../work/ai-quota/">AIQuota for macOS</a></li>
+                <li><a href="../work/resy-search-ai/">Resy AI Exploration</a></li>
+                <li><a href="../work/sendmoi/">SendMoi for iOS &amp; macOS</a></li>
               </ul>
             </nav>
           </div>

--- a/work/ai-quota/index.html
+++ b/work/ai-quota/index.html
@@ -70,7 +70,7 @@
       gtag('js', new Date());
       gtag('config', 'G-DEFM9FZ25D');
     </script>
-    <link rel="stylesheet" href="../../assets/css/work-case-study.css" />
+    <link rel="stylesheet" href="../../assets/css/work-case-study.css?v=20260509-footer-links" />
   </head>
   <body id="top" class="case-study-page work-theme-aiquota is-subpage">
     <div class="work-page">
@@ -582,10 +582,10 @@
             <nav class="site-footer-column site-footer-column-work" aria-label="Case studies sitemap">
               <h3>Case Studies</h3>
               <ul class="site-footer-links">
-                <li><a href="../../work/resy-discovery/">Resy Discovery</a></li>
-                <li><a href="../../work/sendmoi/">SendMoi</a></li>
-                <li><a href="../../work/resy-search-ai/">Somm AI</a></li>
-                <li><a href="../../work/ai-quota/" aria-current="page">AIQuota</a></li>
+                <li><a href="../../work/resy-discovery/">Resy App Discovery</a></li>
+                <li><a href="../../work/ai-quota/" aria-current="page">AIQuota for macOS</a></li>
+                <li><a href="../../work/resy-search-ai/">Resy AI Exploration</a></li>
+                <li><a href="../../work/sendmoi/">SendMoi for iOS &amp; macOS</a></li>
               </ul>
             </nav>
 

--- a/work/index.html
+++ b/work/index.html
@@ -70,7 +70,7 @@
       gtag('js', new Date());
       gtag('config', 'G-DEFM9FZ25D');
     </script>
-    <link rel="stylesheet" href="../assets/css/work-case-study.css" />
+    <link rel="stylesheet" href="../assets/css/work-case-study.css?v=20260509-footer-links" />
   </head>
   <body id="top" class="work-index-page is-subpage">
     <div class="work-page">
@@ -669,9 +669,10 @@
             <nav class="site-footer-column site-footer-column-work" aria-label="Case studies sitemap">
               <h3>Case Studies</h3>
               <ul class="site-footer-links">
-                <li><a href="../work/resy-discovery/">Resy Discovery</a></li>
-                <li><a href="../work/resy-search-ai/">Somm AI</a></li>
-                <li><a href="../work/ai-quota/">AIQuota</a></li>
+                <li><a href="../work/resy-discovery/">Resy App Discovery</a></li>
+                <li><a href="../work/ai-quota/">AIQuota for macOS</a></li>
+                <li><a href="../work/resy-search-ai/">Resy AI Exploration</a></li>
+                <li><a href="../work/sendmoi/">SendMoi for iOS &amp; macOS</a></li>
               </ul>
             </nav>
 

--- a/work/resy-discovery/index.html
+++ b/work/resy-discovery/index.html
@@ -70,7 +70,7 @@
       gtag('js', new Date());
       gtag('config', 'G-DEFM9FZ25D');
     </script>
-    <link rel="stylesheet" href="../../assets/css/work-case-study.css" />
+    <link rel="stylesheet" href="../../assets/css/work-case-study.css?v=20260509-footer-links" />
   </head>
   <body id="top" class="case-study-page is-subpage">
     <div class="work-page">
@@ -688,10 +688,10 @@
             <nav class="site-footer-column site-footer-column-work" aria-label="Case studies sitemap">
               <h3>Case Studies</h3>
               <ul class="site-footer-links">
-                <li><a href="../../work/resy-discovery/" aria-current="page">Resy Discovery</a></li>
-                <li><a href="../../work/sendmoi/">SendMoi</a></li>
-                <li><a href="../../work/resy-search-ai/">Somm AI</a></li>
-                <li><a href="../../work/ai-quota/">AIQuota</a></li>
+                <li><a href="../../work/resy-discovery/" aria-current="page">Resy App Discovery</a></li>
+                <li><a href="../../work/ai-quota/">AIQuota for macOS</a></li>
+                <li><a href="../../work/resy-search-ai/">Resy AI Exploration</a></li>
+                <li><a href="../../work/sendmoi/">SendMoi for iOS &amp; macOS</a></li>
               </ul>
             </nav>
 

--- a/work/resy-search-ai/index.html
+++ b/work/resy-search-ai/index.html
@@ -70,7 +70,7 @@
       gtag('js', new Date());
       gtag('config', 'G-DEFM9FZ25D');
     </script>
-    <link rel="stylesheet" href="../../assets/css/work-case-study.css?v=20260428-0001" />
+    <link rel="stylesheet" href="../../assets/css/work-case-study.css?v=20260509-footer-links" />
   </head>
   <body id="top" class="case-study-page work-theme-sommai is-subpage">
     <div class="work-page">
@@ -534,10 +534,10 @@
             <nav class="site-footer-column site-footer-column-work" aria-label="Case studies sitemap">
               <h3>Case Studies</h3>
               <ul class="site-footer-links">
-                <li><a href="../../work/resy-discovery/">Resy Discovery</a></li>
-                <li><a href="../../work/sendmoi/">SendMoi</a></li>
-                <li><a href="../../work/resy-search-ai/" aria-current="page">Somm AI</a></li>
-                <li><a href="../../work/ai-quota/">AIQuota</a></li>
+                <li><a href="../../work/resy-discovery/">Resy App Discovery</a></li>
+                <li><a href="../../work/ai-quota/">AIQuota for macOS</a></li>
+                <li><a href="../../work/resy-search-ai/" aria-current="page">Resy AI Exploration</a></li>
+                <li><a href="../../work/sendmoi/">SendMoi for iOS &amp; macOS</a></li>
               </ul>
             </nav>
 

--- a/work/sendmoi/index.html
+++ b/work/sendmoi/index.html
@@ -70,7 +70,7 @@
       gtag('js', new Date());
       gtag('config', 'G-DEFM9FZ25D');
     </script>
-    <link rel="stylesheet" href="../../assets/css/work-case-study.css?v=sendmoi-20260508-1" />
+    <link rel="stylesheet" href="../../assets/css/work-case-study.css?v=20260509-footer-links" />
   </head>
   <body id="top" class="case-study-page work-theme-sendmoi is-subpage">
     <div class="work-page">
@@ -608,10 +608,10 @@
             <nav class="site-footer-column site-footer-column-work" aria-label="Case studies sitemap">
               <h3>Case Studies</h3>
               <ul class="site-footer-links">
-                <li><a href="../../work/resy-discovery/">Resy Discovery</a></li>
-                <li><a href="../../work/sendmoi/" aria-current="page">SendMoi</a></li>
-                <li><a href="../../work/resy-search-ai/">Somm AI</a></li>
-                <li><a href="../../work/ai-quota/">AIQuota</a></li>
+                <li><a href="../../work/resy-discovery/">Resy App Discovery</a></li>
+                <li><a href="../../work/ai-quota/">AIQuota for macOS</a></li>
+                <li><a href="../../work/resy-search-ai/">Resy AI Exploration</a></li>
+                <li><a href="../../work/sendmoi/" aria-current="page">SendMoi for iOS &amp; macOS</a></li>
               </ul>
             </nav>
 


### PR DESCRIPTION
## Summary

- Updates footer case-study labels so the right-side footer uses current, descriptive names instead of the stale `Somm AI` shorthand.
- Aligns the footer case-study order with the homepage and recirculation order: Resy App Discovery, AIQuota for macOS, Resy AI Exploration, SendMoi for iOS & macOS.
- Keeps footer case-study links in a single vertical column.
- Refines footer link affordances so Accessibility/Privacy keep a subtle 65% underline while the Site and Case Studies columns remain plain until hover/focus.
- Bumps stylesheet query strings on touched pages so the footer CSS refreshes cleanly after deploy.

## Why

The previous footer still used older project shorthand and a two-column case-study layout that no longer matched the rest of the portfolio. The utility links also needed a more explicit default affordance without making the primary footer columns feel over-underlined.

## Validation

- `git diff --check`
- `make check-sitemap`
- `python3 scripts/check-deploy-2026.py`
- `bash scripts/check-policy-pages.sh`
- `bash scripts/check-launch-case-studies.sh`
- `bash scripts/check-case-study-rail.sh`
- `bash scripts/check-case-study-blocks.sh`
- Live preview spot checks on `http://localhost:8000/work/resy-search-ai/` for footer order and underline behavior