### PR TITLE
Refresh Resy prototype sitemap date

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -38,7 +38,7 @@
   </url>
   <url>
     <loc>https://nieder.me/work/resy-web-booking/prototype/</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-05-11</lastmod>
   </url>
   <url>
     <loc>https://nieder.me/work/sendmoi/</loc>


### PR DESCRIPTION
## Summary
- refresh `sitemap.xml` so the Resy web booking prototype URL matches the generator output
- unblocks the production deploy failure from run 25710272754

## Validation
- `make check-sitemap`
- `python3 scripts/check-deploy-2026.py`
- `git diff --check`

## Notes
- Production deploy failed because `scripts/deploy-prod.sh` reported: `sitemap.xml is out of date. Run scripts/update-sitemap.py.`
- The only generated change is the prototype page `lastmod` date: `2026-05-12` -> `2026-05-11`.