### PR TITLE
AEO: allow answer-engine crawlers, add llms.txt

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,17 @@
+# John Niedermeyer — Product Design & Direction
+# https://nieder.me
+
+> Portfolio of John Niedermeyer, a product design leader based in New York with
+> 20+ years shaping digital products at The New York Times, BuzzFeed, and Resy
+> (American Express Global Dining Network). Currently seeking a Staff or
+> Principal IC product design role, hybrid NYC.
+
+## Pages
+
+- [Home](https://nieder.me/): Introduction, work experience highlights, and case study promos
+- [Work Experience & Resume](https://nieder.me/work/): Full resume, case studies, and downloadable PDF resume
+- [About & Biography](https://nieder.me/about/): Background, design philosophy, and process
+- [Resy App Discovery Case Study](https://nieder.me/work/resy-discovery/): Evolving in-app restaurant discovery for Resy Consumer App
+- [AIQuota Case Study](https://nieder.me/work/ai-quota/): Native macOS menu bar app for tracking AI tool usage (Codex, Claude Code)
+- [Resy AI Search Case Study](https://nieder.me/work/resy-search-ai/): Intent-led restaurant search exploration using AI
+- [SendMoi Case Study](https://nieder.me/work/sendmoi/): iOS & macOS app designed and built with Codex and Claude Code

--- a/robots.txt
+++ b/robots.txt
@@ -13,9 +13,6 @@ Allow: /
 User-agent: Amazonbot
 Disallow: /
 
-User-agent: Applebot-Extended
-Disallow: /
-
 User-agent: Bytespider
 Disallow: /
 

--- a/robots.txt
+++ b/robots.txt
@@ -6,9 +6,10 @@
 # ai-train: training or fine-tuning AI models.
 
 User-agent: *
-Content-Signal: search=yes,ai-train=no
+Content-Signal: search=yes,ai-input=yes,ai-train=no
 Allow: /
 
+# Block AI training crawlers
 User-agent: Amazonbot
 Disallow: /
 
@@ -21,19 +22,7 @@ Disallow: /
 User-agent: CCBot
 Disallow: /
 
-User-agent: ClaudeBot
-Disallow: /
-
 User-agent: CloudflareBrowserRenderingCrawler
-Disallow: /
-
-User-agent: Google-Extended
-Disallow: /
-
-User-agent: GPTBot
-Disallow: /
-
-User-agent: meta-externalagent
 Disallow: /
 
 Sitemap: https://nieder.me/sitemap.xml

--- a/scripts/deploy-2026.sh
+++ b/scripts/deploy-2026.sh
@@ -43,6 +43,7 @@ ROOT_PUBLIC_FILES=(
   apple-touch-icon.png
   favicon.ico
   favicon.png
+  llms.txt
   robots.txt
   sitemap.xml
 )


### PR DESCRIPTION
## Summary

- **robots.txt**: Unblock answer-engine crawlers (ClaudeBot, GPTBot, Google-Extended, meta-externalagent) so ChatGPT, Claude, Gemini, and Meta AI can index the site; update `Content-Signal` to `ai-input=yes`; keep bulk training crawlers (CCBot, Bytespider, Amazonbot) blocked; allow Applebot-Extended (Apple Intelligence training)
- **llms.txt**: New file at root giving AI agents a structured overview of the site — who John is, current availability, and links to all key pages
- **deploy-2026.sh**: Add `llms.txt` to `ROOT_PUBLIC_FILES` so it gets synced on both stage and prod deploys

https://claude.ai/code/session_0156gjsSnsyE6Cb11BHywLfA

---
_Generated by [Claude Code](https://claude.ai/code/session_0156gjsSnsyE6Cb11BHywLfA)_