### PR TITLE
Protect remote-only work deploy files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,3 +14,9 @@
 - Prefer a dedicated `codex/*` branch per task.
 - For parallel work, prefer a repo-local worktree under `.worktrees/`.
 - When you change rendered site files, start or reuse a preview and include the exact URL when reporting the work.
+
+## Deploy safety
+
+- The deploy script uses `rsync --delete` for managed paths.
+- Do not remove the `work/***` rsync protect filter. Remote `/work/` may contain files that are intentionally not part of this repo.
+- If deploy scope changes, run `python3 scripts/check-deploy-2026.py` and verify that remote-only `/work/` files are still protected from deletion.

--- a/README.md
+++ b/README.md
@@ -148,7 +148,14 @@ The script:
 - rewrites the staged homepage site URL
 - cache-busts staged CSS and JS asset URLs across all HTML files
 - syncs only managed paths to the remote target
+- preserves remote-only files under `/work/` even though the repo `work/` tree is deployed
 - is checked by `scripts/check-deploy-2026.py`, which fails if a top-level section exists but is missing from the allowlist
+
+Deploy delete contract:
+
+- `rsync --delete` is allowed for managed deploy paths so removed repo files disappear from staging and production.
+- Remote-only files under `/work/` are intentionally preserved with an rsync protect filter because `/work/` can contain non-repo material.
+- Do not remove that protect filter unless the remote `/work/` tree has first been audited and all non-repo files have been intentionally relocated or imported.
 
 Default settings in `scripts/deploy-2026.sh` can be overridden with environment variables:
 

--- a/scripts/check-deploy-2026.py
+++ b/scripts/check-deploy-2026.py
@@ -14,6 +14,7 @@ required_tokens = [
     'cp -R assets "$STAGING_DIR/"',
     'PUBLIC_DIRS=(',
     'ROOT_PUBLIC_FILES=(',
+    '--filter "P work/***"',
     'favicon.ico',
     'robots.txt',
     'sitemap.xml',

--- a/scripts/deploy-2026.sh
+++ b/scripts/deploy-2026.sh
@@ -22,7 +22,11 @@ DEPLOY_IDENTITY_FILE="${DEPLOY_IDENTITY_FILE:-}"
 
 RSYNC_ARGS=(
   -avz
+  # Delete stale files from managed deploy paths, but never remote-only /work
+  # material. The protect filter below is deliberate; do not remove it just
+  # because work/ is in PUBLIC_DIRS.
   --delete
+  --filter "P work/***"
   --exclude .git/
   --exclude .DS_Store
 )
@@ -106,7 +110,8 @@ RSYNC_SSH_CMD="${RSYNC_SSH_CMD% }"
 "${SSH_CMD[@]}" "${DEPLOY_USER}@${DEPLOY_HOST}" "mkdir -p '${DEPLOY_PATH%/}'"
 
 # Sync only the managed site paths from staging so deploy does not delete
-# unrelated root-level server files such as host-managed config.
+# unrelated root-level server files such as host-managed config. Remote-only
+# files under work/ are protected too; that tree can contain non-repo work.
 SYNC_PATHS=("$STAGING_DIR/index.html" "$STAGING_DIR/assets")
 for file in "${ROOT_PUBLIC_FILES[@]}"; do
   if [[ -f "$STAGING_DIR/$file" ]]; then


### PR DESCRIPTION
## Summary
- Protect remote-only files under `/work/` during deploys by adding an rsync receiver-side protect filter.
- Document the deploy delete contract in `README.md` and `AGENTS.md` so future deploy-scope edits preserve the invariant.
- Extend `scripts/check-deploy-2026.py` so the deploy verifier fails if the `/work/` protect filter is removed.

## Regression history
- `scripts/deploy-2026.sh` has used `rsync --delete` since the original February deploy script.
- The March root-safety hotfix narrowed deploys to explicit managed paths, protecting unrelated root-level server files.
- Because `work/` remained a managed path, `--delete` still recursed inside remote `/work/` and could remove non-repo files there.
- The missing invariant was: remote-only `/work/` files must be preserved even when repo `work/` files are deployed.

## Verification
- `python3 scripts/check-deploy-2026.py`
- `bash -n scripts/deploy-2026.sh scripts/deploy-prod.sh`
- `git diff --check main..HEAD`
- Local rsync simulation confirmed `work/remote-only.html` survives while managed files still update.
