### PR TITLE
Add person structured data

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,44 @@
     <meta name="twitter:url" content="https://nieder.me/" />
     <meta name="twitter:image" content="https://nieder.me/assets/images/og/og-image-1200x630.png" />
     <meta name="twitter:image:alt" content="Preview of John Niedermeyer's product design portfolio." />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@graph": [
+          {
+            "@type": "Person",
+            "@id": "https://nieder.me/#person",
+            "name": "John Niedermeyer",
+            "url": "https://nieder.me/",
+            "image": "https://nieder.me/assets/images/about/portrait_3_4_hp5_2400h.jpg",
+            "jobTitle": "Product Design Leader",
+            "description": "Product design leader based in New York with more than 20 years of experience shaping digital products.",
+            "sameAs": [
+              "https://github.com/niederme/",
+              "https://www.linkedin.com/in/niederme/",
+              "https://x.com/niederme/",
+              "https://instagram.com/niederme/"
+            ]
+          },
+          {
+            "@type": "WebSite",
+            "@id": "https://nieder.me/#website",
+            "url": "https://nieder.me/",
+            "name": "John Niedermeyer",
+            "description": "Portfolio of John Niedermeyer, product design leader with 20+ years shaping digital products at The New York Times, BuzzFeed, and Resy.",
+            "creator": {
+              "@id": "https://nieder.me/#person"
+            },
+            "publisher": {
+              "@id": "https://nieder.me/#person"
+            },
+            "mainEntity": {
+              "@id": "https://nieder.me/#person"
+            }
+          }
+        ]
+      }
+    </script>
     <script>
       (() => {
         try {


### PR DESCRIPTION
## Summary

- add a homepage JSON-LD graph describing John Niedermeyer as the site's primary `Person` entity
- connect the `WebSite` entity through `creator`, `publisher`, and `mainEntity`
- link the visible portrait and existing social profiles

## Why

This gives search engines and answer engines an explicit, stable entity relationship between nieder.me and John Niedermeyer.

## Validation

- JSON-LD graph parses and relationship assertions pass
- `make check-sitemap`
- `git diff --check`
- verified the served homepage graph in the local preview with no console errors

`make check-social` has an existing unrelated failure because `work/resy-web-booking/prototype/index.html` does not include the site's standard social metadata.