### PR TITLE
Refresh sitemap after SEO merge

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -22,7 +22,7 @@
   </url>
   <url>
     <loc>https://nieder.me/work/ai-quota/</loc>
-    <lastmod>2026-06-05</lastmod>
+    <lastmod>2026-06-14</lastmod>
   </url>
   <url>
     <loc>https://nieder.me/work/</loc>
@@ -30,18 +30,18 @@
   </url>
   <url>
     <loc>https://nieder.me/work/resy-discovery/</loc>
-    <lastmod>2026-06-05</lastmod>
+    <lastmod>2026-06-14</lastmod>
   </url>
   <url>
     <loc>https://nieder.me/work/resy-search-ai/</loc>
-    <lastmod>2026-06-05</lastmod>
+    <lastmod>2026-06-14</lastmod>
   </url>
   <url>
     <loc>https://nieder.me/work/resy-web-booking/prototype/</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-06-14</lastmod>
   </url>
   <url>
     <loc>https://nieder.me/work/sendmoi/</loc>
-    <lastmod>2026-06-05</lastmod>
+    <lastmod>2026-06-14</lastmod>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary

Refresh case-study and prototype `lastmod` dates after the SEO metadata squash merge changed their Git history timestamps.

## Validation

- `make check-sitemap`
- production sitemap already deployed with these values