### PR TITLE
Filter weekly analytics to production hosts

### DIFF
--- a/scripts/check-ga4-analytics.sh
+++ b/scripts/check-ga4-analytics.sh
@@ -112,4 +112,11 @@ expect_pattern "privacy/index.html" "Google Analytics" \
 expect_no_pattern "privacy/index.html" "does not currently use advertising, analytics" \
   "Expected privacy/index.html to remove the outdated no-analytics claim."
 
+expect_pattern "scripts/ga4-weekly-report.py" 'field_name="hostName"' \
+  "Expected the weekly GA4 report to filter by production hostname."
+expect_pattern "scripts/ga4-weekly-report.py" 'value=r"^(www\.)?nieder\.me$"' \
+  "Expected the weekly GA4 report to include only nieder.me production hosts."
+expect_pattern "scripts/ga4-weekly-report.py" "dimension_filter=PRODUCTION_HOST_FILTER" \
+  "Expected every weekly GA4 query to use the production hostname filter."
+
 echo "GA4 analytics checks passed."

--- a/scripts/ga4-weekly-report.py
+++ b/scripts/ga4-weekly-report.py
@@ -18,7 +18,8 @@ from pathlib import Path
 from google.oauth2 import service_account
 from google.analytics.data_v1beta import BetaAnalyticsDataClient
 from google.analytics.data_v1beta.types import (
-    DateRange, Dimension, Metric, RunReportRequest, OrderBy
+    DateRange, Dimension, Filter, FilterExpression, Metric, RunReportRequest,
+    OrderBy
 )
 
 # ── credentials ───────────────────────────────────────────────────────────────
@@ -61,10 +62,21 @@ week_start = today - timedelta(days=today.weekday())
 lw_start   = week_start - timedelta(days=7)
 lw_end     = week_start - timedelta(days=1)
 
+PRODUCTION_HOST_FILTER = FilterExpression(
+    filter=Filter(
+        field_name="hostName",
+        string_filter=Filter.StringFilter(
+            match_type=Filter.StringFilter.MatchType.FULL_REGEXP,
+            value=r"^(www\.)?nieder\.me$",
+        ),
+    )
+)
+
 def run_report(start, end, dimensions, metrics, limit=10, order_by=None):
     req = RunReportRequest(
         property=f"properties/{PROPERTY_ID}",
         date_ranges=[DateRange(start_date=str(start), end_date=str(end))],
+        dimension_filter=PRODUCTION_HOST_FILTER,
         dimensions=[Dimension(name=d) for d in dimensions],
         metrics=[Metric(name=m) for m in metrics],
         limit=limit,


### PR DESCRIPTION
## Summary
- filter every weekly GA4 report query to `nieder.me` and `www.nieder.me`
- prevent stale local previews and old worktrees from inflating the weekly report
- enforce the production-host filter in the GA4 analytics check

## Validation
- `./scripts/check-ga4-analytics.sh`
- `./scripts/check-social-metadata.py`
- `./scripts/update-sitemap.py --check`
- production-host GA4 query returns 29 sessions / 25 users / 38 pageviews for June 8-14
- browser verification confirms current main sends zero GA requests on `127.0.0.1`