### PR TITLE
docs: fix stale colophon-style-guide references after /design-system/ rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Core project files:
 - `work/**/*.html` work index and case-study pages
 - `assets/css/styles.css` homepage and shared site styles
 - `assets/css/work-case-study.css` work index and case-study styles
-- `assets/css/styleguide.css` colophon and style-guide styles
+- `assets/css/styleguide.css` design system page styles
 - `assets/js/main.js` shared client-side behavior
 - `assets/images/og/` sitewide and page-specific social share images
 - `assets/` images, icons, fonts, and video
@@ -151,7 +151,7 @@ The script:
 - stages a temporary copy of `index.html` and `assets/`
 - includes allowlisted top-level sections when present
 - generates a fresh `sitemap.xml` directly in the temporary staging tree
-- generates `.htaccess` with the canonical-host redirect (`www.nieder.me` → `nieder.me`), legacy `/portfolio/*` → `/2016/portfolio/*` redirects, `/work/somm-ai/` and `/resy-ai-demo.html` → `/work/resy-search-ai/`, `/sendmoi/*` and `/mailmoi/*` → `send.moi`, the `/colophon` and `/styleguide` → `/colophon-style-guide/` redirects, and the env-aware `ErrorDocument 404` directive (so staging serves `/2026/404.html`)
+- generates `.htaccess` with the canonical-host redirect (`www.nieder.me` → `nieder.me`), legacy `/portfolio/*` → `/2016/portfolio/*` redirects, `/work/somm-ai/` and `/resy-ai-demo.html` → `/work/resy-search-ai/`, `/sendmoi/*` and `/mailmoi/*` → `send.moi`, the `/colophon`, `/colophon-style-guide`, and `/styleguide` → `/design-system/` redirects, and the env-aware `ErrorDocument 404` directive (so staging serves `/2026/404.html`)
 - rewrites `404.html` asset paths to match the deploy prefix (staging vs prod)
 - excludes `drafts/`
 - rewrites the staged homepage site URL

--- a/design-system/design-system.md
+++ b/design-system/design-system.md
@@ -2,7 +2,7 @@
 
 A portable spec for agentic design tools (Claude Design, Figma Make, v0, Lovable, Cursor, etc.).
 Values are extracted from the production CSS in `assets/css/styles.css` and the living style
-guide at `/colophon-style-guide/`. Machine-readable tokens live alongside this file in
+guide at `/design-system/`. Machine-readable tokens live alongside this file in
 `design-tokens.json` (W3C Design Tokens format).
 
 ## Principles
@@ -81,5 +81,5 @@ Step values observed across gaps/margins: `5, 8, 10, 12, 15, 20, 24, 28, 40` (px
 ## Source of truth
 
 - Tokens & component CSS: `assets/css/styles.css`, `assets/css/styleguide.css`, `assets/css/work-case-study.css`
-- Live specimen page: `colophon-style-guide/index.html`
+- Live specimen page: `design-system/index.html`
 - Fonts: `assets/fonts/soehne-*.woff2`


### PR DESCRIPTION
Documentation-only cleanup following the `/design-system/` rename in #134. No rendered-site or deploy-behavior changes.

- `README.md:154` corrected — the deploy section described the legacy redirects as pointing to `/colophon-style-guide/`; they now point to `/design-system/` (and `/colophon-style-guide` itself is a redirect source).
- `README.md:40` — CSS note reworded from "colophon and style-guide styles" to "design system page styles."
- `design-system/design-system.md` — two self-references to the old slug (`/colophon-style-guide/` and `colophon-style-guide/index.html`) updated to `design-system`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)