### PR TITLE
Revise About page copy and lede styling

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -227,7 +227,7 @@
                 and, most recently, as Principal Designer at Resy, where I worked across the full product suite from
                 consumer to operator.
               </p>
-              <p>
+              <p class="about-lede">
                 I’ve spent my career in the fuzzy overlap between product, editorial, brand, and implementation:
                 evolving brands, shaping experiences, and understanding how they’re built. Along the way, I’ve moved
                 between Individual Contributor and People Leadership roles, helping teams build trust, alignment, and

--- a/about/index.html
+++ b/about/index.html
@@ -221,98 +221,50 @@
 
           <article class="work-article-body">
             <section class="work-article-section">
-              <h2>Overview</h2>
-              <p>
-                I’m John Niedermeyer, a product design leader based in New York. I’ve spent two decades
-                shaping products and brands across startups, newsrooms, and scaled platforms — including nearly eight
-                years at The New York Times and most recently as Principal Designer at Resy, where I worked across the
-                full product suite from consumer to operator.
+              <p class="about-lede">
+                As a Product Design leader based in New York the past two decades, I’ve shaped products and brands
+                across startups, newsrooms, and scaled platforms, including nearly eight years at The New York Times
+                and, most recently, as Principal Designer at Resy, where I worked across the full product suite from
+                consumer to operator.
               </p>
               <p>
-                My career has lived in the overlap between product, editorial, brand, and implementation: evolving
-                brands, shaping experiences, making production code changes when the work called for it, and moving
-                between IC and team lead roles. That range isn’t incidental. I see design thinking as a discipline that
-                scales well beyond its traditional domain: applicable to how organizations make decisions, how teams
-                build shared vocabulary, how products earn and lose trust over time.
+                I’ve spent my career in the fuzzy overlap between product, editorial, brand, and implementation:
+                evolving brands, shaping experiences, and understanding how they’re built. Along the way, I’ve moved
+                between Individual Contributor and People Leadership roles, helping teams build trust, alignment, and
+                shared ownership.
               </p>
             </section>
 
             <section class="work-article-section">
               <h2>Philosophy</h2>
               <p>
-                Design, to me, is thinking, editing, experimenting, and refining. Not a phase or a deliverable — a way
-                of working through hard problems, at any stage of a project, across almost any discipline that benefits
-                from clarity, iteration, and judgment.
-              </p>
-              <p>
-                At every level, good design means <em>demonstrating</em> understanding. But I’ve come to believe that
-                at the senior level, demonstrating is only the beginning. The more important thing is being able to
-                articulate <em>why</em> something works — and then teach it. That progression from doing to explaining
-                to teaching isn’t just career growth; it’s the mechanism by which design culture propagates. A lot of
-                the work I’m most proud of happened off the artboard: in crits where I helped someone see what they
-                were actually solving for, in documentation that outlived the project, in frameworks that gave a team a
-                shared language for what "good" meant.
-              </p>
-              <p>
-                I’m also drawn to work where editorial sensibility and product rigor have to coexist — where the answer
-                isn’t just "make it usable" or "make it beautiful" but something harder: make it <em>considered</em>.
-                Taste and systems aren’t opposites. They’re in constant negotiation, and getting that balance right is
-                most of the job. The best work I’ve been part of had strong visual craft and scalable thinking, and
-                neither survived long without the other.
+                The best teams I’ve worked on shared ownership across disciplines. Designers contributed product
+                ideas, Engineers shaped the user experience, and Product Managers influenced the craft. Titles
+                mattered less than curiosity, trust, and a shared commitment to making the work better. I’ve found
+                that the strongest products emerge from the same conditions: clear thinking, thoughtful collaboration,
+                and a willingness to stay close to both the people using a product, and the people building it.
               </p>
             </section>
 
             <section class="work-article-section">
               <h2>Process</h2>
               <p>
-                My process has two registers: a macro view across a project and a tighter loop within each problem.
-              </p>
-              <p>
-                At the macro level, I work through phases: Define, Explore, Refine, Build, Learn. Not in strict
-                sequence — some projects need to reach Learn fast and iterate from there; others need longer in Explore
-                before anything gets committed. The phases are a shared vocabulary for where a project is and what it
-                needs, not a checklist to complete in order.
-              </p>
-              <p>
-                At the micro level, the loop is: Gather, Synthesize, Make, Communicate. Take in information, make
-                sense of it, produce the right artifact at the right fidelity, get it in front of the right people,
-                repeat. This cycle happens in an afternoon and across a quarter. It’s the atomic unit of the work
-                regardless of phase.
-              </p>
-              <p>
-                In practice: I go wide before I go narrow. I ask a lot of questions early — especially about
-                constraints and what "done" actually means. I try to make decisions visible, surfacing the tradeoffs
-                behind a choice, not just the choice itself. I stay close through implementation, because the gap
-                between a comp and a shipped component is where quality tends to get lost. I come back after launch to
-                see what changed.
-              </p>
-              <p>
-                I believe in tool agnosticism paired with toolkit curiosity. The frameworks and methods matter; the
-                specific software doesn’t. That disposition has made it easier to stay current as the toolkit shifts —
-                and right now it’s shifting fast. I’m especially interested in how LLM-assisted workflows are changing
-                what’s possible in design, both as a practitioner and as someone who designs products that use these
-                capabilities.
+                Years ago, I helped develop a
+                <a href="https://medium.com/buzzfeed-design/introducing-buzzfeeds-design-process-4fefbdcd83ea" target="_blank" rel="noopener noreferrer">design
+                process at BuzzFeed</a> built around defining problems, exploring
+                possibilities, refining solutions, building, and learning from what shipped. I still work that way
+                today, though less as a framework and more as a reminder that good design is iterative. The goal isn’t
+                to follow a process perfectly: it’s to learn quickly, make progress visible, and keep improving the
+                work.
               </p>
             </section>
 
             <section class="work-article-section" id="today">
               <h2>Today</h2>
               <p>
-                Right now I’m working independently — shipping products, taking on engagements, and looking for what’s
-                next. I’m actively seeking a Staff or Principal IC product design role, ideally hybrid in New York.
-              </p>
-              <p>
-                The work I’m most drawn to involves teams building two-sided products — platforms where consumer and
-                operator experiences have to cohere, where the design problems aren’t just about usability but about the
-                relationship between two very different sets of needs. I’m open to the right agency context too.
-              </p>
-              <p>
-                Most of all, I’m looking for teams where trust and accountability go together — where there’s real
-                ownership, real feedback, and a shared investment in getting things right. That’s the environment where
-                I tend to do my best work.
-              </p>
-              <p>
-                If any of this resonates, I’d love to talk.
+                Right now, I’m working independently while exploring what’s next. I’m drawn to complex product
+                ecosystems, collaborative teams, and environments where design can influence not just the interface,
+                but the strategy and systems behind it. The work is important, but so are the people doing it.
               </p>
             </section>
 

--- a/assets/css/work-case-study.css
+++ b/assets/css/work-case-study.css
@@ -973,6 +973,14 @@ body.grid-hidden .work-grid-overlay > span {
 }
 
 /* About page */
+/* Opening paragraph: lede-scale type at normal body width (no width change). */
+.work-article-section p.about-lede {
+  font-size: 24px;
+  line-height: 1.35;
+  letter-spacing: -0.01em;
+  font-weight: 300;
+}
+
 .about-portrait {
   grid-column: 10 / span 3;
   grid-row: 1;


### PR DESCRIPTION
Tighter, first-person rewrite of the `/about/` page copy, plus a lede treatment for the opening.

### Copy
- New copy across the intro, **Philosophy**, **Process**, and **Today** sections.
- Dropped the redundant **Overview** heading so the page opens straight on the lede.
- Capitalized discipline names (Designers, Engineers, Product Managers) for consistency with "Individual Contributor" / "People Leadership."
- Linked "design process at BuzzFeed" to the [BuzzFeed Design article](https://medium.com/buzzfeed-design/introducing-buzzfeeds-design-process-4fefbdcd83ea).
- Curly quotes/apostrophes throughout, no em dashes.

### Styling
- Added `.about-lede` (24px / weight 300) applied to both intro paragraphs. Borrows the case-study lede's *type* but keeps normal body width, so it doesn't collide with the portrait. Scoped as `.work-article-section p.about-lede` to win specificity over the base paragraph rule.

### Notes / left as-is
- Section headings kept terse (Philosophy / Process / Today).
- The **Availability** sidebar card still reads "Seeking Staff / Principal IC role," while the new Today prose is more understated — intentional for now (card carries the explicit signal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)