### PR TITLE
Refine mobile card media layout

### DIFF
--- a/assets/css/work-case-study.css
+++ b/assets/css/work-case-study.css
@@ -4285,10 +4285,11 @@ body.grid-hidden .work-grid-overlay > span {
   .work-article-body .case-study-reference-card:hover,
   .work-article-body .case-study-reference-card:focus-visible,
   .work-article-body .case-study-reference-card:active {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr) minmax(92px, 30%);
+    column-gap: 18px;
     justify-content: stretch;
+    align-items: start;
     border-radius: 25px;
-    row-gap: 16px;
     padding: 18px;
   }
 
@@ -4325,7 +4326,7 @@ body.grid-hidden .work-grid-overlay > span {
   .case-study-reference-card-media {
     width: 100%;
     border-radius: 12px;
-    aspect-ratio: 287 / 161;
+    aspect-ratio: 4 / 3;
   }
 
   .case-study-callout-eyebrow {
@@ -5320,8 +5321,14 @@ body.grid-hidden .work-grid-overlay > span {
   }
 
   .blog-index-card {
-    grid-template-columns: 1fr;
-    row-gap: 24px;
+    grid-template-columns: minmax(0, 1fr) minmax(92px, 30%);
+    column-gap: 18px;
+    align-items: start;
+    padding: 18px;
+  }
+
+  .blog-index-card-media {
+    aspect-ratio: 4 / 3;
   }
 }
 


### PR DESCRIPTION
## Summary
- keep blog index card media as a compact right-side thumbnail at the existing mobile breakpoint
- apply the same compact media treatment to case-study reference cards on mobile
- add an explicit 18px column gap so copy and media do not crowd the rule/border area

## Validation
- npm run build
- make check-social
- ./scripts/check-mobile-nav-visibility.sh
- measured blog and Resy mobile cards at 390x844: no horizontal overflow, 18px copy/media gap, 4:3 thumbnail media