### PR TITLE
Run blog index heading on one line

### DIFF
--- a/assets/css/work-case-study.css
+++ b/assets/css/work-case-study.css
@@ -5147,10 +5147,6 @@ body.grid-hidden .work-grid-overlay > span {
   color: var(--fg);
 }
 
-.blog-index-title-line {
-  display: block;
-}
-
 .blog-index-title-accent {
   color: var(--accent);
 }

--- a/blog-source/index.njk
+++ b/blog-source/index.njk
@@ -9,8 +9,7 @@ eleventyExcludeFromCollections: true
 <section class="work-index-header blog-index-header" aria-labelledby="blog-title">
   <div class="work-index-header-copy blog-index-header-copy">
     <h1 id="blog-title" class="blog-index-title">
-      <span class="blog-index-title-line"><span class="blog-index-title-accent">NiederBlog:</span> Notes &amp;</span>
-      <span class="blog-index-title-line">Essays on Design</span>
+      <span class="blog-index-title-accent">NiederBlog:</span> Notes &amp; Essays on Design
     </h1>
   </div>
 </section>


### PR DESCRIPTION
Collapses the blog index branding heading from a forced two-line split into a single line: red "NiederBlog:" followed by white "Notes & Essays on Design".

## Changes
- `blog-source/index.njk`: removed the two `.blog-index-title-line` spans so the heading flows as one line
- `assets/css/work-case-study.css`: removed the now-unused `.blog-index-title-line { display: block }` rule

## Notes
- No `white-space: nowrap` — the heading still wraps naturally on very narrow screens, where `clamp(34px…72px)` scales the size down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)