### PR TITLE
Add white tagline to article/archive top nav

### DIFF
--- a/assets/css/work-case-study.css
+++ b/assets/css/work-case-study.css
@@ -5147,6 +5147,10 @@ body.grid-hidden .work-grid-overlay > span {
   color: var(--fg);
 }
 
+.blog-index-title-line {
+  display: block;
+}
+
 .blog-index-title-accent {
   color: var(--accent);
 }
@@ -5339,11 +5343,16 @@ body.grid-hidden .work-grid-overlay > span {
 .blog-top-nav {
   display: flex;
   align-items: center;
+  gap: 0.6ch;
   min-height: 78px;
   margin: 0 0 0 var(--case-study-edge-inset);
   font-size: 22px;
   line-height: 1.2;
   font-weight: 700;
+}
+
+.blog-top-nav-tagline {
+  color: var(--fg);
 }
 
 .blog-top-nav a,

--- a/blog-source/_includes/post.njk
+++ b/blog-source/_includes/post.njk
@@ -6,6 +6,7 @@ layout: base.njk
 {%- for tag in tags -%}{% if tag != "posts" %}{% set displayTags = (displayTags.push(tag), displayTags) %}{% endif %}{%- endfor -%}
 <nav class="blog-top-nav" aria-label="Blog navigation">
   <a href="{{ root }}blog/">NiederBlog</a>
+  <span class="blog-top-nav-tagline">Notes &amp; Essays on Design</span>
 </nav>
 
 <section class="work-index-header blog-post-header" aria-labelledby="post-title">

--- a/blog-source/index.njk
+++ b/blog-source/index.njk
@@ -9,7 +9,8 @@ eleventyExcludeFromCollections: true
 <section class="work-index-header blog-index-header" aria-labelledby="blog-title">
   <div class="work-index-header-copy blog-index-header-copy">
     <h1 id="blog-title" class="blog-index-title">
-      <span class="blog-index-title-accent">NiederBlog:</span> Notes &amp; Essays on Design
+      <span class="blog-index-title-line"><span class="blog-index-title-accent">NiederBlog:</span> Notes &amp;</span>
+      <span class="blog-index-title-line">Essays on Design</span>
     </h1>
   </div>
 </section>

--- a/blog-source/tags.njk
+++ b/blog-source/tags.njk
@@ -1,5 +1,6 @@
 <nav class="blog-top-nav" aria-label="Blog navigation">
   <a href="{{ page.url | relRoot }}blog/">NiederBlog</a>
+  <span class="blog-top-nav-tagline">Notes &amp; Essays on Design</span>
 </nav>
 
 <section class="work-index-header blog-post-header" aria-labelledby="tag-title">


### PR DESCRIPTION
The small top nav on article and tag (archive) pages now shows the brand plus tagline on one line: accent **NiederBlog** + white **Notes & Essays on Design**, separated by a small gap (no colon).

## Changes
- `post.njk` + `tags.njk`: added a `.blog-top-nav-tagline` span after the NiederBlog link
- `work-case-study.css`: `gap: 0.6ch` on `.blog-top-nav` for spacing; `.blog-top-nav-tagline { color: var(--fg) }` (white in dark, adapts in light)
- Restored the forced two-line break on the `/blog` index heading (markup spans + `.blog-index-title-line { display: block }`), reverting #145 per request

## Notes
- Stacked on top of #144; only adds one line to `tags.njk`, preserving the archive-promo work.
- Tagline uses `var(--fg)` so it stays correct in both themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)