### PR TITLE
Add RSS autodiscovery link to head

### DIFF
--- a/blog-source/_includes/base.njk
+++ b/blog-source/_includes/base.njk
@@ -18,6 +18,7 @@
     <title>{{ title }} | {{ site.name }}</title>
     <meta name="description" content="{{ description }}" />
     <link rel="canonical" href="{{ pageUrlAbs }}" />
+    <link rel="alternate" type="application/rss+xml" title="{{ site.name }} — NiederBlog" href="{{ root }}feed.xml" />
 
     <meta property="og:type" content="{{ ogType }}" />
     <meta property="og:locale" content="en_US" />


### PR DESCRIPTION
Adds the `<link rel="alternate" type="application/rss+xml">` autodiscovery tag to `<head>` so browsers, feed readers, and "subscribe" buttons can find `/feed.xml` automatically. Previously the feed existed but was undiscoverable — readers had to know the URL by hand.

## Changes
- `base.njk`: autodiscovery `<link>` after the canonical tag, `href="{{ root }}feed.xml"` (uses `relRoot`, so it resolves on both the `/2026` staging path and production)

## Verified
- `/blog/` → `../feed.xml`, article page → `../../feed.xml`; both resolve to root `/feed.xml`.

## Heads-up (not addressed here)
The staging feed mixes URL bases: channel `<link>`/`xml:base` use the `/2026/` staging path, while `atom:self` and item links use prod URLs (`https://nieder.me/...`). Likely consistent on the production build, but worth a separate check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)