### PR TITLE
Tag archive header: match the /blog index treatment

### DIFF
--- a/blog-source/tags.njk
+++ b/blog-source/tags.njk
@@ -3,11 +3,12 @@
   <span class="blog-top-nav-tagline">Notes &amp; Essays on Design</span>
 </nav>
 
-<section class="work-index-header blog-post-header" aria-labelledby="tag-title">
-  <div class="rule"></div>
-  <div class="work-index-header-copy">
-    <h1 id="tag-title">#{{ tag }}</h1>
-    <h2>Tagged notes</h2>
+<section class="work-index-header blog-index-header" aria-labelledby="tag-title">
+  <div class="work-index-header-copy blog-index-header-copy">
+    <h1 id="tag-title" class="blog-index-title">
+      <span class="blog-index-title-line">Notes</span>
+      <span class="blog-index-title-line"><span class="blog-index-title-accent">#{{ tag }}</span></span>
+    </h1>
   </div>
 </section>
 


### PR DESCRIPTION
Makes tag archive pages read like a filtered `/blog` instead of a divergent, heavier page.

- Swaps the big `work-index-header` (`#tag / Tagged notes`) for the index's `blog-index-header` / `blog-index-title` treatment, so title scale + spacing match `/blog` by construction.
- Header now reads **"Notes / #tag"** — drops the redundant "Tagged" per feedback.
- Keeps the top-nav tagline (#146); reuses existing index classes, **no CSS changes**.
- Verified at 1900px against `/blog`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
