### PR TITLE
Blog top-nav: fully clickable, brand-only underline on hover

### DIFF
--- a/assets/css/work-case-study.css
+++ b/assets/css/work-case-study.css
@@ -5357,14 +5357,28 @@ body.grid-hidden .work-grid-overlay > span {
 
 .blog-top-nav a,
 .blog-top-nav a:visited {
-  color: var(--accent);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6ch;
+  color: inherit;
   text-decoration: none;
-  transition: color 0.18s ease;
 }
 
-.blog-top-nav a:hover,
-.blog-top-nav a:focus-visible {
+/* Whole nav is clickable; only the brand picks up the link underline on hover. */
+.blog-top-nav-brand {
+  color: var(--accent);
+  text-decoration-line: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.16em;
+  text-decoration-skip-ink: auto;
+  text-decoration-color: transparent;
+  transition: color 0.18s ease, text-decoration-color 0.18s ease;
+}
+
+.blog-top-nav a:hover .blog-top-nav-brand,
+.blog-top-nav a:focus-visible .blog-top-nav-brand {
   color: var(--accent-hover);
+  text-decoration-color: var(--text-link-underline);
 }
 
 .blog-post-category {

--- a/blog-source/_includes/post.njk
+++ b/blog-source/_includes/post.njk
@@ -5,8 +5,10 @@ layout: base.njk
 {%- set displayTags = [] -%}
 {%- for tag in tags -%}{% if tag != "posts" %}{% set displayTags = (displayTags.push(tag), displayTags) %}{% endif %}{%- endfor -%}
 <nav class="blog-top-nav" aria-label="Blog navigation">
-  <a href="{{ root }}blog/">NiederBlog</a>
-  <span class="blog-top-nav-tagline">Notes &amp; Essays on Design</span>
+  <a href="{{ root }}blog/">
+    <span class="blog-top-nav-brand">NiederBlog</span>
+    <span class="blog-top-nav-tagline">Notes &amp; Essays on Design</span>
+  </a>
 </nav>
 
 <section class="work-index-header blog-post-header" aria-labelledby="post-title">

--- a/blog-source/tags.njk
+++ b/blog-source/tags.njk
@@ -1,6 +1,8 @@
 <nav class="blog-top-nav" aria-label="Blog navigation">
-  <a href="{{ page.url | relRoot }}blog/">NiederBlog</a>
-  <span class="blog-top-nav-tagline">Notes &amp; Essays on Design</span>
+  <a href="{{ page.url | relRoot }}blog/">
+    <span class="blog-top-nav-brand">NiederBlog</span>
+    <span class="blog-top-nav-tagline">Notes &amp; Essays on Design</span>
+  </a>
 </nav>
 
 <section class="work-index-header blog-index-header" aria-labelledby="tag-title">


### PR DESCRIPTION
The top-nav ("NiederBlog Notes & Essays on Design") was only clickable on the word "NiederBlog". This wraps the whole nav (brand + tagline) in a single link so the entire thing is clickable, while keeping the fancy link underline scoped to **only the brand** on hover (tagline stays plain white).

- Markup: one `<a>` wrapping `.blog-top-nav-brand` + `.blog-top-nav-tagline`, in both `tags.njk` and `post.njk`.
- CSS: link is `inline-flex` (preserves the `0.6ch` gap); brand carries the underline (transparent → `--text-link-underline` on hover); tagline unchanged.
- Verified: clickable area spans both spans; on hover only the brand shows `text-decoration: underline` with the translucent-red color, tagline `none`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
