### PR TITLE
[codex] Add blog pager dates and isolate dev preview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ node_modules/
 
 # Generated blog build artifacts (rebuilt locally and in CI; never hand-edited)
 /_site/
+/.eleventy-dev/
 /blog/
 /admin/
 /feed.xml

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ make build      # one-off build into blog/, feed.xml, admin/
 make dev        # static preview of the whole site (run make build first)
 ```
 
-`blog/`, `admin/`, `feed.xml`, and `sitemap.xml` are generated build output and are gitignored — never hand-edit them. CI runs `npm ci && npm run build` (with the environment-appropriate `SITE_URL`) before checks, minification, and deploy.
+`npm run dev` serves from `.eleventy-dev/` so it can keep running while one-off builds use `_site/`. `blog/`, `admin/`, `feed.xml`, and `sitemap.xml` are generated build output and are gitignored — never hand-edit them. CI runs `npm ci && npm run build` (with the environment-appropriate `SITE_URL`) before checks, minification, and deploy.
 
 ### Content manager (`/admin/`)
 

--- a/assets/css/work-case-study.css
+++ b/assets/css/work-case-study.css
@@ -5540,6 +5540,13 @@ body.grid-hidden .work-grid-overlay > span {
   transition: color 0.18s ease;
 }
 
+.blog-post-pager-date {
+  font-size: 16px;
+  line-height: 1.35;
+  font-weight: 400;
+  color: var(--footer-meta);
+}
+
 a.blog-post-pager-link:hover .blog-post-pager-title,
 a.blog-post-pager-link:focus-visible .blog-post-pager-title {
   color: var(--accent);

--- a/blog-source/_includes/post.njk
+++ b/blog-source/_includes/post.njk
@@ -63,12 +63,14 @@ layout: base.njk
   <a class="blog-post-pager-link blog-post-pager-prev" href="{{ olderPost.url | relUrl(page.url) }}">
     <span class="blog-post-pager-label">← Previous</span>
     <span class="blog-post-pager-title">{{ olderPost.data.title }}</span>
+    <time class="blog-post-pager-date" datetime="{{ olderPost.data.date | dateISO }}">{{ olderPost.data.date | dateDisplay }}</time>
   </a>
   {%- else %}<span class="blog-post-pager-prev" aria-hidden="true"></span>{% endif -%}
   {%- if newerPost %}
   <a class="blog-post-pager-link blog-post-pager-next" href="{{ newerPost.url | relUrl(page.url) }}">
     <span class="blog-post-pager-label">Next →</span>
     <span class="blog-post-pager-title">{{ newerPost.data.title }}</span>
+    <time class="blog-post-pager-date" datetime="{{ newerPost.data.date | dateISO }}">{{ newerPost.data.date | dateDisplay }}</time>
   </a>
   {%- else %}<span class="blog-post-pager-next" aria-hidden="true"></span>{% endif -%}
 </nav>

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "type": "module",
   "scripts": {
     "clean:blog": "node scripts/clean-blog-output.mjs",
+    "clean:blog-dev": "node scripts/clean-blog-dev-output.mjs",
     "build": "npm run clean:blog && eleventy --config=.eleventy.cjs && node scripts/place-blog-output.mjs",
-    "dev": "npm run clean:blog && ELEVENTY_INCLUDE_DRAFTS=1 eleventy --config=.eleventy.cjs --serve --watch"
+    "dev": "npm run clean:blog-dev && ELEVENTY_INCLUDE_DRAFTS=1 eleventy --config=.eleventy.cjs --output=.eleventy-dev --serve --watch"
   },
   "devDependencies": {
     "@11ty/eleventy": "^3.0.0",

--- a/scripts/clean-blog-dev-output.mjs
+++ b/scripts/clean-blog-dev-output.mjs
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+// Removes only the 11ty live-preview output. Keep this separate from the build
+// scratch dir so `npm run build` cannot delete an active `make dev-blog` server.
+import { rm } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, join, resolve } from "node:path";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const target = join(ROOT, ".eleventy-dev");
+
+await rm(target, { recursive: true, force: true });
+console.log("Cleaned blog preview output: .eleventy-dev");


### PR DESCRIPTION
## Summary

- Adds publication dates beneath previous/next blog pager titles using the site's existing footer/meta gray token.
- Moves the 11ty live preview output to `.eleventy-dev/` so `npm run build` no longer deletes the active `make dev-blog` server output.
- Documents the separate preview output directory and ignores it in git.

## Validation

- `npm run build`
- `make dev-blog BLOG_PORT=8083`, then confirmed the post URL returned 200 before and after a separate `npm run build`
- Browser check confirmed the pager date renders as `June 24, 2026` with computed color `rgb(142, 143, 152)` and no console warnings/errors