### PR TITLE
Convert blog index to full-text stream with pagination

### DIFF
--- a/assets/css/work-case-study.css
+++ b/assets/css/work-case-study.css
@@ -5385,6 +5385,58 @@ body.about-page .work-article-meta {
   color: var(--accent);
 }
 
+/* Full-text stream (blog index river). Post bodies reuse .blog-post-body. */
+.blog-stream {
+  display: flex;
+  flex-direction: column;
+}
+
+.blog-stream-item {
+  display: flex;
+  flex-direction: column;
+}
+
+.blog-stream-head {
+  margin: 0 0 22px;
+}
+
+.blog-stream-kicker {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin: 0 0 10px;
+  font-size: 16px;
+  line-height: 1.35;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.blog-stream-title {
+  margin: 0;
+  font-size: var(--case-study-heading-size);
+  line-height: var(--case-study-heading-line-height);
+  font-weight: var(--case-study-heading-weight);
+  letter-spacing: 0;
+  color: var(--fg);
+  text-wrap: pretty;
+}
+
+.blog-stream-title a,
+.blog-stream-title a:visited {
+  color: inherit;
+  text-decoration: none;
+  transition: color 0.18s ease;
+}
+
+.blog-stream-title a:hover,
+.blog-stream-title a:focus-visible {
+  color: var(--accent);
+}
+
+.blog-stream-rule {
+  margin: 56px 0;
+}
+
 @media (min-width: 960px) and (max-width: 1320px) {
   .blog-index-body {
     grid-column: 1 / span 8;

--- a/blog-source/index.njk
+++ b/blog-source/index.njk
@@ -3,9 +3,17 @@ layout: base.njk
 pageType: index
 title: "NiederBlog"
 description: "Notes and essays on design by John Niedermeyer."
-permalink: /blog/index.html
 eleventyExcludeFromCollections: true
+pagination:
+  data: collections.posts
+  size: 10
+  alias: streamPosts
+permalink: "/blog/{% if pagination.pageNumber > 0 %}page/{{ pagination.pageNumber + 1 }}/{% endif %}index.html"
 ---
+{%- set olderHref = pagination.href.next -%}
+{%- set newerHref = pagination.href.previous -%}
+{%- set olderLead = pagination.pages[pagination.pageNumber + 1][0] if olderHref else null -%}
+{%- set newerLead = pagination.pages[pagination.pageNumber - 1][0] if newerHref else null -%}
 <section class="work-index-header blog-index-header" aria-labelledby="blog-title">
   <div class="work-index-header-copy blog-index-header-copy">
     <h1 id="blog-title" class="blog-index-title">
@@ -16,37 +24,34 @@ eleventyExcludeFromCollections: true
 </section>
 
 <section class="blog-index-shell" aria-labelledby="blog-title">
-  <article class="blog-index-body">
-    {% if collections.posts.length %}
-    <ul class="blog-index-list">
-      {%- for post in collections.posts %}
-      <li class="blog-index-item">
-        <a class="blog-index-card" href="{{ post.url | relUrl(page.url) }}">
-          <span class="blog-index-card-copy">
-            <span class="blog-index-card-kicker">
-              <span>{{ post.data.category if post.data.category else "Notes" }}</span>
-              <span aria-hidden="true">|</span>
-              <time datetime="{{ post.data.date | dateISO }}">{{ post.data.date | dateDisplay }}</time>
-            </span>
-            <strong>{{ post.data.title }}</strong>
-            <em>{{ post.data.description }}</em>
-            <b>Read post →</b>
-          </span>
-          {% if post.data.socialImage %}
-          <span class="blog-index-card-media" aria-hidden="true">
-            <img src="{{ post.data.socialImage | relUrl(page.url) }}" alt="" loading="lazy" />
-          </span>
-          {% endif %}
-        </a>
-      </li>
+  <div class="blog-index-body">
+    {% if streamPosts.length %}
+    <div class="blog-stream">
+      {%- for post in streamPosts %}
+      <article class="blog-stream-item">
+        <header class="blog-stream-head">
+          <p class="blog-stream-kicker">
+            <span>{{ post.data.category if post.data.category else "Notes" }}</span>
+            <span aria-hidden="true">|</span>
+            <time datetime="{{ post.data.date | dateISO }}">{{ post.data.date | dateDisplay }}</time>
+          </p>
+          <h2 class="blog-stream-title">
+            <a href="{{ post.url | relUrl(page.url) }}">{{ post.data.title }}</a>
+          </h2>
+        </header>
+        <div class="blog-post-body blog-stream-body">
+          {{ post.templateContent | safe }}
+        </div>
+        {%- if not loop.last %}<div class="rule blog-stream-rule"></div>{% endif -%}
+      </article>
       {%- endfor %}
-    </ul>
+    </div>
     {% else %}
     <section class="work-article-section">
       <p>No posts yet. Check back soon.</p>
     </section>
     {% endif %}
-  </article>
+  </div>
 
   {% if collections.tagList.length %}
   <aside class="blog-index-topics" aria-label="Browse by topic">
@@ -59,3 +64,35 @@ eleventyExcludeFromCollections: true
   </aside>
   {% endif %}
 </section>
+
+{%- if olderHref or newerHref %}
+<nav class="work-article-grid blog-post-pager blog-stream-pager" aria-label="More posts">
+  <div class="rule blog-post-pager-rule"></div>
+  {%- if olderHref %}
+  <a class="blog-post-pager-link blog-post-pager-prev" href="{{ olderHref | relUrl(page.url) }}">
+    <span class="blog-post-pager-label">← Older posts</span>
+    {%- if olderLead %}
+    <span class="blog-post-pager-kicker">
+      <span>{{ olderLead.data.category if olderLead.data.category else "Notes" }}</span>
+      <span aria-hidden="true">|</span>
+      <time datetime="{{ olderLead.data.date | dateISO }}">{{ olderLead.data.date | dateDisplay }}</time>
+    </span>
+    <span class="blog-post-pager-title">{{ olderLead.data.title }}</span>
+    {%- endif %}
+  </a>
+  {%- else %}<span class="blog-post-pager-prev" aria-hidden="true"></span>{% endif -%}
+  {%- if newerHref %}
+  <a class="blog-post-pager-link blog-post-pager-next" href="{{ newerHref | relUrl(page.url) }}">
+    <span class="blog-post-pager-label">Newer posts →</span>
+    {%- if newerLead %}
+    <span class="blog-post-pager-kicker">
+      <span>{{ newerLead.data.category if newerLead.data.category else "Notes" }}</span>
+      <span aria-hidden="true">|</span>
+      <time datetime="{{ newerLead.data.date | dateISO }}">{{ newerLead.data.date | dateDisplay }}</time>
+    </span>
+    <span class="blog-post-pager-title">{{ newerLead.data.title }}</span>
+    {%- endif %}
+  </a>
+  {%- else %}<span class="blog-post-pager-next" aria-hidden="true"></span>{% endif -%}
+</nav>
+{% endif -%}

--- a/docs/superpowers/specs/2026-06-30-blog-full-text-stream-design.md
+++ b/docs/superpowers/specs/2026-06-30-blog-full-text-stream-design.md
@@ -30,6 +30,9 @@ gets out of the way.
   `blog-source/_includes/post.njk` (rule + two-column Previous/Next with a
   "category | date" kicker and a title). Labeled "Older posts" / "Newer
   posts"; no numbered page list.
+- **Tag pages:** Left as-is — compact archive cards. The `/blog/` river is a
+  reading surface; tag pages (`blog-source/tags.njk`) are filter/archive views
+  where scannable cards beat full text. They keep using `.blog-index-card*`.
 
 ## Design
 
@@ -43,12 +46,13 @@ pagination:
   data: collections.posts
   size: 10
   alias: streamPosts
-  reverse: true        # newest first
 permalink: "/blog/{% if pagination.pageNumber > 0 %}page/{{ pagination.pageNumber + 1 }}/{% endif %}index.html"
 ```
 
-- `reverse: true` yields newest-first, matching the existing date-descending
-  `collections.posts` ordering used elsewhere.
+- **No `reverse: true`.** The `posts` collection is already sorted
+  date-descending (newest-first) in `.eleventy.cjs` (`addCollection("posts")`,
+  ~line 158). 11ty's `reverse` reverses the source array, so setting it would
+  flip page 1 to oldest-first. Paginating the collection as-is is correct.
 - Page 1 keeps the canonical `/blog/` URL; subsequent pages get
   `/blog/page/N/`.
 - The page header section and the Topics aside (`collections.tagList`) stay as
@@ -93,15 +97,20 @@ when that page exists. No numbered list.
 
 Add a small block of `.blog-stream-*` rules near the existing blog section
 (rules start ~line 5282). Reuse `.blog-post-body` typography for the rendered
-content so streamed essays look identical to their standalone pages. Remove
-`.blog-index-card*` rules that become unused so the file does not accrete dead
-CSS; keep any shared kicker styling that the stream still references.
+content so streamed essays look identical to their standalone pages.
+
+**Delete nothing.** The `.blog-index-card*` rules are still used by the tag
+archive pages (`blog-source/tags.njk`), which we are intentionally leaving as
+compact cards. Add the new stream styles alongside the existing card styles.
 
 ## Verification
 
 - `make dev-blog` (11ty `--serve --watch`, port 8080) live-reloads while
   editing templates/posts.
-- Page 1 renders all current posts in full, newest first, at `/blog/`.
+- Page 1 renders all current posts in full, **newest first** (confirm the
+  drop of `reverse: true` did not invert the order), at `/blog/`.
+- Tag archive pages (`/blog/tags/<tag>/`) still render compact cards and are
+  visually unchanged.
 - Each item's title links to its working standalone post page.
 - With only 3 posts, the bottom pager does not render (single page); confirm it
   appears and links correctly once post count exceeds 10 (temporarily lower
@@ -115,4 +124,5 @@ CSS; keep any shared kicker styling that the stream still references.
 - Link-blog / "linked list" post type.
 - Manual "more"/fold excerpt marker.
 - Numbered pagination controls.
+- Converting tag archive pages to full-text (they stay as compact cards).
 - RSS/feed changes — the feed already carries full post content independently.

--- a/docs/superpowers/specs/2026-06-30-blog-full-text-stream-design.md
+++ b/docs/superpowers/specs/2026-06-30-blog-full-text-stream-design.md
@@ -1,0 +1,118 @@
+# Blog Index as a Full-Text Stream
+
+**Date:** 2026-06-30
+**Status:** Approved, ready for implementation plan
+
+## Goal
+
+Replace the teaser-card blog index at `/blog/` with a Daring Fireball–style
+river: every post rendered in full, newest first, each with its own
+category/date kicker and a permalink, paginated 10 posts per page.
+
+The teaser-card pattern (kicker, title, description, "Read post →", optional
+image, each linking out to a standalone post) earns its keep at high post
+volume. For a low-volume blog of short essays (current posts run 200–735
+words), the cards are mostly friction between reader and writing. A stream
+gets out of the way.
+
+## Decisions
+
+- **Post type:** Author's own essays only, shown in full. No link-blog /
+  "linked list" post type (that is a separate content-model addition, out of
+  scope).
+- **Content length:** Full text, no truncation. No manual "more"/fold marker
+  for now — it is a cheap add later (11ty excerpt separator) if a long essay
+  ever forces the issue, and starting full-text-only does not paint us into a
+  corner.
+- **Pagination:** 10 posts per page. Page 1 at `/blog/`; page 2+ at
+  `/blog/page/2/`, `/blog/page/3/`, …
+- **Pager:** Reuse the existing in-post `.blog-post-pager` pattern from
+  `blog-source/_includes/post.njk` (rule + two-column Previous/Next with a
+  "category | date" kicker and a title). Labeled "Older posts" / "Newer
+  posts"; no numbered page list.
+
+## Design
+
+### 1. Template & pagination — `blog-source/index.njk`
+
+Convert the index from a single static page into a paginated page driven by
+11ty's `pagination` over `collections.posts`:
+
+```yaml
+pagination:
+  data: collections.posts
+  size: 10
+  alias: streamPosts
+  reverse: true        # newest first
+permalink: "/blog/{% if pagination.pageNumber > 0 %}page/{{ pagination.pageNumber + 1 }}/{% endif %}index.html"
+```
+
+- `reverse: true` yields newest-first, matching the existing date-descending
+  `collections.posts` ordering used elsewhere.
+- Page 1 keeps the canonical `/blog/` URL; subsequent pages get
+  `/blog/page/N/`.
+- The page header section and the Topics aside (`collections.tagList`) stay as
+  they are today.
+- Remove `eleventyExcludeFromCollections: true` only if needed; the index is
+  not itself a post, so it must not enter `collections.posts`. Verify the
+  paginated index does not recursively include itself.
+
+### 2. Each stream item
+
+Replace the card markup. For each `post` in `streamPosts`, render inline:
+
+- **Kicker line:** `category` (default "Notes") · date, reusing the existing
+  `.blog-index-card-kicker` typographic treatment.
+- **Title:** an `<h2>` whose link points at the standalone post
+  (`post.url | relUrl(page.url)`) — the per-post permalink, the site's
+  equivalent of DF's "★".
+- **Full body:** `{{ post.templateContent | safe }}`, wrapped so it inherits
+  `.blog-post-body` typography (identical to the standalone post page).
+- **Divider:** a thin `.rule` between items.
+
+The standalone post pages and their per-post pager (`post.njk`) are untouched;
+those permalinks still exist and still work.
+
+### 3. Bottom pager
+
+Reuse the `.blog-post-pager` markup/styling from `post.njk`, pointing at pages
+rather than single posts. Each side previews the **lead (boundary) post of the
+adjacent page**:
+
+- **← Older posts** — kicker + title of the first (newest) post on the older
+  page → `…/page/N+1/`.
+- **Newer posts →** — kicker + title of the first post on the newer page →
+  back toward `/blog/`.
+
+Use `pagination.href.next` / `pagination.href.previous` for the URLs. Derive
+each side's boundary post from `collections.posts` by page offset
+(`pageNumber × size`), accounting for the reversed order. Render a side only
+when that page exists. No numbered list.
+
+### 4. Styling — `assets/css/work-case-study.css`
+
+Add a small block of `.blog-stream-*` rules near the existing blog section
+(rules start ~line 5282). Reuse `.blog-post-body` typography for the rendered
+content so streamed essays look identical to their standalone pages. Remove
+`.blog-index-card*` rules that become unused so the file does not accrete dead
+CSS; keep any shared kicker styling that the stream still references.
+
+## Verification
+
+- `make dev-blog` (11ty `--serve --watch`, port 8080) live-reloads while
+  editing templates/posts.
+- Page 1 renders all current posts in full, newest first, at `/blog/`.
+- Each item's title links to its working standalone post page.
+- With only 3 posts, the bottom pager does not render (single page); confirm it
+  appears and links correctly once post count exceeds 10 (temporarily lower
+  `size` to verify, then restore to 10).
+- The index does not appear inside its own stream.
+- `npm run build` produces `/blog/index.html` plus `/blog/page/N/` for
+  additional pages, with no broken links.
+
+## Out of scope
+
+- Link-blog / "linked list" post type.
+- Manual "more"/fold excerpt marker.
+- Numbered pagination controls.
+- RSS/feed changes — the feed already carries full post content independently.


### PR DESCRIPTION
## What & why

Rebuilds the `/blog/` index as a Daring Fireball–style full-text stream instead of teaser cards. For a low-volume blog of short essays (current posts run 200–735 words), the promo cards were mostly friction between reader and writing. The stream renders each post in full, newest first, so the page reads like writing rather than CMS output.

## Changes

- **`blog-source/index.njk`** — index is now a paginated river:
  - Paginates `collections.posts`, 10 per page. Page 1 stays at `/blog/`; page 2+ at `/blog/page/N/`.
  - No `reverse: true` — the `posts` collection is already sorted newest-first in `.eleventy.cjs`, and 11ty's `reverse` would have flipped page 1 to oldest-first.
  - Each item: category · date kicker, an `<h2>` title linking to the standalone post (the permalink), then the full post body via `templateContent`, wrapped in `.blog-post-body` so it reads identically to the standalone page. Thin rule between items.
  - Bottom pager reuses the in-post `.blog-post-pager` pattern, labeled "← Older posts" / "Newer posts →", each side previewing the adjacent page's lead post and rendering only when that page exists.
- **`assets/css/work-case-study.css`** — adds a `.blog-stream-*` block reusing existing heading/body tokens. Deletes nothing; the `.blog-index-card*` rules still serve the tag pages.

## Deliberately unchanged / out of scope

- **Tag pages** (`/blog/tags/<tag>/`) keep their compact promo cards — they're a lookup/archive surface where scannable cards beat full text.
- No link-blog post type, no manual "more"/fold marker, no numbered pagination, no feed changes (the RSS feed already carries full content).

## Verification

- `npm run build` succeeds; `/blog/` renders all 3 posts in full, newest first (Jun 25 → Jun 24 23:48 → Jun 24 17:00), zero cards, zero "Read post →".
- Temporarily set page size to 2: page 1 showed a one-sided "← Older posts" → `page/2/` previewing "Love at First Sketch"; page 2 showed "Newer posts →" → `/blog/` previewing "What's Left for Us to Do". Relative URLs resolve correctly. Restored to 10 — `page/2/` gone, no pager on the single page.
- Tag pages still render cards, visually unchanged.

**Note:** With only 3 posts, the pager stays invisible in production until there are 11+ posts. Logic is verified via the size-2 test above.

Design spec: `docs/superpowers/specs/2026-06-30-blog-full-text-stream-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
