### PR TITLE
Refine blog stream: eyebrow, foot date, headline scale

### DIFF
--- a/assets/css/work-case-study.css
+++ b/assets/css/work-case-study.css
@@ -5401,24 +5401,23 @@ body.about-page .work-article-meta {
 }
 
 .blog-stream-kicker {
-  display: flex;
-  align-items: baseline;
-  gap: 8px;
-  margin: 0 0 10px;
+  margin: 0 0 6px;
   font-size: 16px;
   line-height: 1.35;
   font-weight: 700;
   color: var(--accent);
 }
 
+/* Enlarged, headline-scale title. White like the article masthead, accent on
+   hover; the size + hover pointer carry the clickable cue. */
 .blog-stream-title {
   margin: 0;
-  font-size: var(--case-study-heading-size);
-  line-height: var(--case-study-heading-line-height);
-  font-weight: var(--case-study-heading-weight);
-  letter-spacing: 0;
+  font-size: clamp(26px, 2.8vw, 36px);
+  line-height: 1.08;
+  font-weight: 700;
+  letter-spacing: -0.02em;
   color: var(--fg);
-  text-wrap: pretty;
+  text-wrap: balance;
 }
 
 .blog-stream-title a,
@@ -5431,6 +5430,36 @@ body.about-page .work-article-meta {
 .blog-stream-title a:hover,
 .blog-stream-title a:focus-visible {
   color: var(--accent);
+}
+
+/* Foot permalink: muted date linking to the standalone post (DF-style). */
+.blog-stream-permalink {
+  margin: 24px 0 0;
+  font-size: 15px;
+  line-height: 1.3;
+  font-weight: 400;
+}
+
+.blog-stream-permalink a,
+.blog-stream-permalink a:visited {
+  color: var(--muted);
+  text-decoration: none;
+  transition: color 0.18s ease;
+}
+
+.blog-stream-permalink a:hover,
+.blog-stream-permalink a:focus-visible {
+  color: var(--accent);
+}
+
+/* The lede scale belongs to the standalone article page only. In the stream,
+   render the lead paragraph at normal body size. Scoped tighter than
+   `.blog-post-body > p.lede` so it wins regardless of source order. */
+.blog-stream-item .blog-stream-body > p.lede {
+  font-size: var(--case-study-text-size);
+  line-height: var(--case-study-text-line-height);
+  font-weight: var(--case-study-text-weight);
+  letter-spacing: 0;
 }
 
 .blog-stream-rule {

--- a/blog-source/index.njk
+++ b/blog-source/index.njk
@@ -30,11 +30,7 @@ permalink: "/blog/{% if pagination.pageNumber > 0 %}page/{{ pagination.pageNumbe
       {%- for post in streamPosts %}
       <article class="blog-stream-item">
         <header class="blog-stream-head">
-          <p class="blog-stream-kicker">
-            <span>{{ post.data.category if post.data.category else "Notes" }}</span>
-            <span aria-hidden="true">|</span>
-            <time datetime="{{ post.data.date | dateISO }}">{{ post.data.date | dateDisplay }}</time>
-          </p>
+          <p class="blog-stream-kicker">{{ post.data.category if post.data.category else "Notes" }}</p>
           <h2 class="blog-stream-title">
             <a href="{{ post.url | relUrl(page.url) }}">{{ post.data.title }}</a>
           </h2>
@@ -42,6 +38,12 @@ permalink: "/blog/{% if pagination.pageNumber > 0 %}page/{{ pagination.pageNumbe
         <div class="blog-post-body blog-stream-body">
           {{ post.templateContent | safe }}
         </div>
+        <p class="blog-stream-permalink">
+          <a href="{{ post.url | relUrl(page.url) }}">
+            <time datetime="{{ post.data.date | dateISO }}">{{ post.data.date | dateDisplay }}</time>
+            <span aria-hidden="true"> →</span>
+          </a>
+        </p>
         {%- if not loop.last %}<div class="rule blog-stream-rule"></div>{% endif -%}
       </article>
       {%- endfor %}


### PR DESCRIPTION
Follow-up refinements to the blog full-text stream (#154), from live design review.

## Changes

- **Eyebrow → category only.** The item eyebrow now reads just the category (e.g. "Notes"); the "| June 25, 2026" is gone.
- **Date → foot permalink.** Each post gets a muted, regular-weight date line at its foot that links to the standalone post (Daring Fireball style). Keeps the date for readers while leaving the head clean.
- **Headline tuned.** Enlarged to a real heading scale — `clamp(26px, 2.8vw, 36px)` — white, tighter tracking, accent-red on hover. Eyebrow-to-headline gap tightened to 6px to match the coupling used elsewhere.
- **Lede reset in the stream.** The `.lede` scale is overridden to body size inside `.blog-stream-body` (scoped tighter than `.blog-post-body > p.lede` so it wins), so the lead paragraph no longer balloons on the index. The lede scale is unchanged on the standalone article page.

## Notes

- The foot date uses the shared `--muted` token (`#ebebf5` in dark mode), the site's standard secondary-text color — consistent with the article-page meta, though it reads near-white by design.
- Tag pages remain unchanged (compact cards).

## Verification

`npm run build` succeeds; `/blog/` renders eyebrow = "Notes" only, a dated foot permalink per post, the resized headline, and body-size lead paragraphs. Verified in a local static preview of the built output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
