### PR TITLE
Rebrand blog tagline and redesign stream foot meta

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -227,7 +227,7 @@
             </div>
             <div class="work-article-meta-card">
               <p class="work-article-meta-label">Availability</p>
-              <p class="work-article-meta-value">Seeking Staff / Principal IC role, hybrid NYC</p>
+              <p class="work-article-meta-value">Seeking Senior, Staff, or Principal IC Product Design role, hybrid NYC</p>
             </div>
           </aside>
 

--- a/assets/css/work-case-study.css
+++ b/assets/css/work-case-study.css
@@ -5436,24 +5436,51 @@ body.about-page .work-article-meta {
   color: var(--accent);
 }
 
-/* Foot permalink: muted date linking to the standalone post (DF-style). */
-.blog-stream-permalink {
-  margin: 24px 0 0;
-  font-size: 15px;
-  line-height: 1.3;
-  font-weight: 400;
+/* Foot meta row: the article page's right-rail meta (Published / Byline /
+   Tags) laid out horizontally, without the card boxes. The date doubles as
+   the permalink. Groups are split by a hairline; each group hugs its rule,
+   with the gap before the rule breathing with the viewport. */
+.blog-stream-foot {
+  margin: 32px 0 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px clamp(28px, 4vw, 64px);
 }
 
-.blog-stream-permalink a,
-.blog-stream-permalink a:visited {
+.blog-stream-foot .work-article-meta-card {
+  border: none;
+  padding: 0;
+}
+
+.blog-stream-foot .work-article-meta-card + .work-article-meta-card {
+  margin-top: 0;
+  border-left: 1px solid var(--line);
+  padding-left: 20px;
+}
+
+/* At narrow widths, keep the same ruled horizontal layout, just tighter. */
+@media (max-width: 640px) {
+  .blog-stream-foot {
+    gap: 16px 20px;
+  }
+
+  .blog-stream-foot .work-article-meta-card + .work-article-meta-card {
+    padding-left: 14px;
+  }
+}
+
+.blog-stream-foot .work-article-meta-value {
   color: var(--muted);
-  text-decoration: none;
-  transition: color 0.18s ease;
 }
 
-.blog-stream-permalink a:hover,
-.blog-stream-permalink a:focus-visible {
-  color: var(--accent);
+/* Undo the rail's 8px tag-list offset so tags share the value baseline. */
+.blog-stream-foot .blog-tag-list {
+  margin-top: 0;
+  line-height: 1.35;
+}
+
+.blog-stream-foot .blog-tag {
+  line-height: 1.35;
 }
 
 /* The lede scale belongs to the standalone article page only. In the stream,
@@ -5660,6 +5687,14 @@ body.about-page .work-article-meta {
 .blog-index-topics .blog-tag {
   display: inline-block;
   line-height: 1.25;
+}
+
+.blog-stream-foot .blog-tag-list {
+  gap: 8px 12px;
+}
+
+.blog-stream-foot .blog-tag {
+  display: inline-block;
 }
 
 .blog-index-topics .blog-tag-list {

--- a/blog-source/_includes/post.njk
+++ b/blog-source/_includes/post.njk
@@ -8,9 +8,9 @@ layout: base.njk
   <a href="{{ root }}blog/">
     <span class="blog-top-nav-line">
       <span class="blog-top-nav-brand">NiederBlog:</span>
-      <span class="blog-top-nav-tagline">Notes &amp;</span>
+      <span class="blog-top-nav-tagline">Notes on</span>
     </span>
-    <span class="blog-top-nav-line blog-top-nav-tagline">Essays on Design</span>
+    <span class="blog-top-nav-line blog-top-nav-tagline">Design &amp; Miscellany</span>
   </a>
 </nav>
 

--- a/blog-source/index.njk
+++ b/blog-source/index.njk
@@ -17,8 +17,8 @@ permalink: "/blog/{% if pagination.pageNumber > 0 %}page/{{ pagination.pageNumbe
 <section class="work-index-header blog-index-header" aria-labelledby="blog-title">
   <div class="work-index-header-copy blog-index-header-copy">
     <h1 id="blog-title" class="blog-index-title">
-      <span class="blog-index-title-line"><span class="blog-index-title-accent">NiederBlog:</span> Notes &amp;</span>
-      <span class="blog-index-title-line">Essays on Design</span>
+      <span class="blog-index-title-line"><span class="blog-index-title-accent">NiederBlog:</span> Notes on</span>
+      <span class="blog-index-title-line">Design &amp; Miscellany</span>
     </h1>
   </div>
 </section>
@@ -38,12 +38,33 @@ permalink: "/blog/{% if pagination.pageNumber > 0 %}page/{{ pagination.pageNumbe
         <div class="blog-post-body blog-stream-body">
           {{ post.templateContent | safe }}
         </div>
-        <p class="blog-stream-permalink">
-          <a href="{{ post.url | relUrl(page.url) }}">
-            <time datetime="{{ post.data.date | dateISO }}">{{ post.data.date | dateDisplay }}</time>
-            <span aria-hidden="true"> →</span>
-          </a>
-        </p>
+        {%- set displayTags = [] -%}
+        {%- for tag in post.data.tags -%}{% if tag != "posts" %}{% set displayTags = (displayTags.push(tag), displayTags) %}{% endif %}{%- endfor -%}
+        <footer class="blog-stream-foot" aria-label="Post metadata">
+          <div class="work-article-meta-card">
+            <p class="work-article-meta-label">Published</p>
+            <p class="work-article-meta-value">
+              <a href="{{ post.url | relUrl(page.url) }}">
+                <time datetime="{{ post.data.date | dateISO }}">{{ post.data.date | dateDisplay }}</time>
+                <span aria-hidden="true"> →</span>
+              </a>
+            </p>
+          </div>
+          <div class="work-article-meta-card">
+            <p class="work-article-meta-label">Byline</p>
+            <p class="work-article-meta-value">John Niedermeyer</p>
+          </div>
+          {%- if displayTags.length %}
+          <div class="work-article-meta-card">
+            <p class="work-article-meta-label">Tags</p>
+            <ul class="blog-tag-list">
+              {%- for tag in displayTags %}
+              <li><a class="blog-tag" href="{{ page.url | relRoot }}blog/tags/{{ tag | tagSlug }}/">#{{ tag }}</a></li>
+              {%- endfor %}
+            </ul>
+          </div>
+          {%- endif %}
+        </footer>
         {%- if not loop.last %}<div class="rule blog-stream-rule"></div>{% endif -%}
       </article>
       {%- endfor %}

--- a/blog-source/tags.njk
+++ b/blog-source/tags.njk
@@ -1,7 +1,7 @@
 <nav class="blog-top-nav" aria-label="Blog navigation">
   <a href="{{ page.url | relRoot }}blog/">
     <span class="blog-top-nav-brand">NiederBlog</span>
-    <span class="blog-top-nav-tagline">Notes &amp; Essays on Design</span>
+    <span class="blog-top-nav-tagline">Notes on Design &amp; Miscellany</span>
   </a>
 </nav>
 

--- a/index.html
+++ b/index.html
@@ -300,7 +300,7 @@
               <div class="experience-column">
                 <article class="experience-item experience-item-current">
                   <h4>Currently</h4>
-                  <p>Seeking a full-time hybrid (NYC) Staff/Principal IC Product Design role.</p>
+                  <p>Currently seeking a full-time hybrid Senior, Staff, or Principal IC Product Design role in New York City.</p>
                 </article>
 
                 <article class="experience-item">

--- a/index.html
+++ b/index.html
@@ -477,8 +477,8 @@
             <header class="blog-home-heading">
               <h3 id="blog-home-title" class="blog-home-lockup">
                 <a class="blog-home-lockup-link" href="blog/">
-                  <span class="blog-home-lockup-line"><span class="blog-home-lockup-brand">NiederBlog:</span> Notes &amp;</span>
-                  <span class="blog-home-lockup-line">Essays on Design</span>
+                  <span class="blog-home-lockup-line"><span class="blog-home-lockup-brand">NiederBlog:</span> Notes on</span>
+                  <span class="blog-home-lockup-line">Design &amp; Miscellany</span>
                 </a>
               </h3>
             </header>

--- a/llms.txt
+++ b/llms.txt
@@ -3,8 +3,8 @@
 
 > Portfolio of John Niedermeyer, a product design leader based in New York with
 > 20+ years shaping digital products at The New York Times, BuzzFeed, and Resy
-> (American Express Global Dining Network). Currently seeking a Staff or
-> Principal IC product design role, hybrid NYC.
+> (American Express Global Dining Network). Currently seeking a full-time
+> hybrid Senior, Staff, or Principal IC Product Design role in New York City.
 
 ## Pages
 

--- a/work/index.html
+++ b/work/index.html
@@ -211,7 +211,7 @@
         <section class="work-index-intro" aria-labelledby="work-index-intro-title">
           <h3 id="work-index-intro-title" class="visually-hidden">Resume introduction</h3>
           <p class="work-index-lede">
-            Currently seeking a full-time hybrid Staff/Principal IC Product Design role in New York City.
+            Currently seeking a full-time hybrid Senior, Staff, or Principal IC Product Design role in New York City.
           </p>
           <p class="work-index-download-wrap">
             <a


### PR DESCRIPTION
## Summary
- Rebrand the blog lockup from "NiederBlog: Notes & Essays on Design" to "NiederBlog: Notes on Design & Miscellany" across the blog index H1, homepage blog section, post-page nav, and tag-page nav
- Replace the bare date permalink at the foot of each blog index post with a horizontal version of the article page's right-rail meta: Published / Byline / Tags, separated by vertical hairlines, groups anchored close to their rule with the gap flexing by viewport
- Keep the same ruled horizontal layout on mobile with tighter spacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)