### PR TITLE
Move work experience below blog

### DIFF
--- a/index.html
+++ b/index.html
@@ -286,83 +286,6 @@
 
         <div class="mobile-nav-sentinel" aria-hidden="true"></div>
 
-        <section class="work-experience" id="work-experience">
-          <div class="rule"></div>
-          <div class="experience-grid">
-            <header class="experience-heading">
-              <h3>Work Experience</h3>
-              <p class="resume-link-wrap">
-                <a class="resume-link" href="work/">Full Work Experience &amp; Resume →</a>
-              </p>
-            </header>
-
-            <div class="experience-columns-carousel">
-              <div class="experience-column">
-                <article class="experience-item experience-item-current">
-                  <h4>Currently</h4>
-                  <p>Currently seeking a full-time hybrid Senior, Staff, or Principal IC Product Design role in New York City.</p>
-                </article>
-
-                <article class="experience-item">
-                  <h4>Indie Product/Designer/Engineer</h4>
-                  <p class="experience-company experience-company-plain">Self</p>
-                  <p class="experience-date">Sept. 2025 - Present</p>
-                </article>
-
-                <article class="experience-item">
-                  <h4>Principal Designer</h4>
-                  <p class="experience-company"><a href="https://resy.com" target="_blank" rel="noopener noreferrer">Resy (American Express Global Dining Network)</a></p>
-                  <p class="experience-date">Feb. 2022 - June 2025</p>
-                </article>
-
-                <article class="experience-item">
-                  <h4>Head of Design / Design Lead</h4>
-                  <p class="experience-company"><a href="https://resy.com" target="_blank" rel="noopener noreferrer">Resy</a></p>
-                  <p class="experience-date">Feb. 2017 - Feb. 2022</p>
-                </article>
-
-                <article class="experience-item">
-                  <h4>Head of Design</h4>
-                  <p class="experience-company"><a href="https://web.archive.org/web/20170122080526/https://waywardwild.com/" target="_blank" rel="noopener noreferrer">Wayward Wild</a></p>
-                  <p class="experience-date">Dec. 2016 - Feb. 2017 (Investment fell through)</p>
-                </article>
-              </div>
-
-              <div class="experience-column">
-                <article class="experience-item">
-                  <h4>Product Design Manager</h4>
-                  <p class="experience-company"><a href="https://buzzfeed.com" target="_blank" rel="noopener noreferrer">BuzzFeed</a></p>
-                  <p class="experience-date">April 2015 - Sept. 2016</p>
-                </article>
-
-                <article class="experience-item">
-                  <h4>Deputy Editor, Digital News Design</h4>
-                  <p class="experience-company"><a href="https://nytimes.com" target="_blank" rel="noopener noreferrer">The New York Times</a></p>
-                  <p class="experience-date">Jan. 2014 - April 2015</p>
-                </article>
-
-                <article class="experience-item">
-                  <h4>Design Lead, Digital News Design</h4>
-                  <p class="experience-company"><a href="https://nytimes.com" target="_blank" rel="noopener noreferrer">The New York Times</a></p>
-                  <p class="experience-date">Mar. 2012 - Jan. 2014</p>
-                </article>
-
-                <article class="experience-item">
-                  <h4>Editorial Designer, Digital Design</h4>
-                  <p class="experience-company"><a href="https://nytimes.com" target="_blank" rel="noopener noreferrer">The New York Times</a></p>
-                  <p class="experience-date">Nov. 2007 - Mar. 2012</p>
-                </article>
-
-                <article class="experience-item">
-                  <h4>Manager, Web &amp; Multimedia Services</h4>
-                  <p class="experience-company"><a href="https://www.lionbridge.com" target="_blank" rel="noopener noreferrer">Lionbridge, Framingham, Mass.</a></p>
-                  <p class="experience-date">Nov. 2006 - July 2007</p>
-                </article>
-              </div>
-            </div>
-          </div>
-        </section>
-
         <section class="case-study-promos" id="case-study-promos" aria-label="Case study promos">
           <article
             id="case-study-resy"
@@ -511,6 +434,83 @@
                 </li>
               </ul>
               <a class="blog-home-all" href="blog/">All posts &rarr;</a>
+            </div>
+          </div>
+        </section>
+
+        <section class="work-experience" id="work-experience">
+          <div class="rule"></div>
+          <div class="experience-grid">
+            <header class="experience-heading">
+              <h3>Work Experience</h3>
+              <p class="resume-link-wrap">
+                <a class="resume-link" href="work/">Full Work Experience &amp; Resume →</a>
+              </p>
+            </header>
+
+            <div class="experience-columns-carousel">
+              <div class="experience-column">
+                <article class="experience-item experience-item-current">
+                  <h4>Currently</h4>
+                  <p>Currently seeking a full-time hybrid Senior, Staff, or Principal IC Product Design role in New York City.</p>
+                </article>
+
+                <article class="experience-item">
+                  <h4>Indie Product/Designer/Engineer</h4>
+                  <p class="experience-company experience-company-plain">Self</p>
+                  <p class="experience-date">Sept. 2025 - Present</p>
+                </article>
+
+                <article class="experience-item">
+                  <h4>Principal Designer</h4>
+                  <p class="experience-company"><a href="https://resy.com" target="_blank" rel="noopener noreferrer">Resy (American Express Global Dining Network)</a></p>
+                  <p class="experience-date">Feb. 2022 - June 2025</p>
+                </article>
+
+                <article class="experience-item">
+                  <h4>Head of Design / Design Lead</h4>
+                  <p class="experience-company"><a href="https://resy.com" target="_blank" rel="noopener noreferrer">Resy</a></p>
+                  <p class="experience-date">Feb. 2017 - Feb. 2022</p>
+                </article>
+
+                <article class="experience-item">
+                  <h4>Head of Design</h4>
+                  <p class="experience-company"><a href="https://web.archive.org/web/20170122080526/https://waywardwild.com/" target="_blank" rel="noopener noreferrer">Wayward Wild</a></p>
+                  <p class="experience-date">Dec. 2016 - Feb. 2017 (Investment fell through)</p>
+                </article>
+              </div>
+
+              <div class="experience-column">
+                <article class="experience-item">
+                  <h4>Product Design Manager</h4>
+                  <p class="experience-company"><a href="https://buzzfeed.com" target="_blank" rel="noopener noreferrer">BuzzFeed</a></p>
+                  <p class="experience-date">April 2015 - Sept. 2016</p>
+                </article>
+
+                <article class="experience-item">
+                  <h4>Deputy Editor, Digital News Design</h4>
+                  <p class="experience-company"><a href="https://nytimes.com" target="_blank" rel="noopener noreferrer">The New York Times</a></p>
+                  <p class="experience-date">Jan. 2014 - April 2015</p>
+                </article>
+
+                <article class="experience-item">
+                  <h4>Design Lead, Digital News Design</h4>
+                  <p class="experience-company"><a href="https://nytimes.com" target="_blank" rel="noopener noreferrer">The New York Times</a></p>
+                  <p class="experience-date">Mar. 2012 - Jan. 2014</p>
+                </article>
+
+                <article class="experience-item">
+                  <h4>Editorial Designer, Digital Design</h4>
+                  <p class="experience-company"><a href="https://nytimes.com" target="_blank" rel="noopener noreferrer">The New York Times</a></p>
+                  <p class="experience-date">Nov. 2007 - Mar. 2012</p>
+                </article>
+
+                <article class="experience-item">
+                  <h4>Manager, Web &amp; Multimedia Services</h4>
+                  <p class="experience-company"><a href="https://www.lionbridge.com" target="_blank" rel="noopener noreferrer">Lionbridge, Framingham, Mass.</a></p>
+                  <p class="experience-date">Nov. 2006 - July 2007</p>
+                </article>
+              </div>
             </div>
           </div>
         </section>


### PR DESCRIPTION
## Summary

- move the homepage Work Experience section below NiederBlog
- preserve all section content and markup

## Validation

- user verified the change in the local preview
- `git diff --check`