### PR TITLE
Use brand red for browser chrome

### DIFF
--- a/404.html
+++ b/404.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <meta name="theme-color" content="#000000" />
+    <meta name="theme-color" content="#ff453a" />
     <meta name="color-scheme" content="dark" />
     <meta name="robots" content="noindex" />
     <link rel="icon" href="/favicon.ico?v=8aef762bbe84" sizes="any" />
@@ -50,9 +50,7 @@
           if (storedTheme === "light") {
             document.documentElement.dataset.theme = "light";
             document.documentElement.style.colorScheme = "light";
-            const themeColorMeta = document.querySelector('meta[name="theme-color"]');
             const colorSchemeMeta = document.querySelector('meta[name="color-scheme"]');
-            if (themeColorMeta) themeColorMeta.setAttribute("content", "#ffffff");
             if (colorSchemeMeta) colorSchemeMeta.setAttribute("content", "light");
           }
         } catch (error) {

--- a/about/index.html
+++ b/about/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <meta name="theme-color" content="#000000" />
+    <meta name="theme-color" content="#ff453a" />
     <meta name="color-scheme" content="dark" />
     <link rel="icon" href="/favicon.ico?v=8aef762bbe84" sizes="any" />
     <link rel="icon" type="image/png" href="/favicon.png?v=8aef762bbe84" />
@@ -49,9 +49,7 @@
           if (storedTheme === "light") {
             document.documentElement.dataset.theme = "light";
             document.documentElement.style.colorScheme = "light";
-            const themeColorMeta = document.querySelector('meta[name="theme-color"]');
             const colorSchemeMeta = document.querySelector('meta[name="color-scheme"]');
-            if (themeColorMeta) themeColorMeta.setAttribute("content", "#ffffff");
             if (colorSchemeMeta) colorSchemeMeta.setAttribute("content", "light");
           }
         } catch (error) {

--- a/accessibility/index.html
+++ b/accessibility/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <meta name="theme-color" content="#000000" />
+    <meta name="theme-color" content="#ff453a" />
     <meta name="color-scheme" content="dark" />
     <link rel="icon" href="/favicon.ico?v=8aef762bbe84" sizes="any" />
     <link rel="icon" type="image/png" href="/favicon.png?v=8aef762bbe84" />
@@ -49,9 +49,7 @@
           if (storedTheme === "light") {
             document.documentElement.dataset.theme = "light";
             document.documentElement.style.colorScheme = "light";
-            const themeColorMeta = document.querySelector('meta[name="theme-color"]');
             const colorSchemeMeta = document.querySelector('meta[name="color-scheme"]');
-            if (themeColorMeta) themeColorMeta.setAttribute("content", "#ffffff");
             if (colorSchemeMeta) colorSchemeMeta.setAttribute("content", "light");
           }
         } catch (error) {

--- a/blog-source/_includes/base.njk
+++ b/blog-source/_includes/base.njk
@@ -10,7 +10,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <meta name="theme-color" content="#000000" />
+    <meta name="theme-color" content="#ff453a" />
     <meta name="color-scheme" content="dark" />
     <link rel="icon" href="{{ root }}favicon.ico?v={{ site.faviconVersion }}" sizes="any" />
     <link rel="icon" type="image/png" href="{{ root }}favicon.png?v={{ site.faviconVersion }}" />
@@ -48,9 +48,7 @@
           if (storedTheme === "light") {
             document.documentElement.dataset.theme = "light";
             document.documentElement.style.colorScheme = "light";
-            const themeColorMeta = document.querySelector('meta[name="theme-color"]');
             const colorSchemeMeta = document.querySelector('meta[name="color-scheme"]');
-            if (themeColorMeta) themeColorMeta.setAttribute("content", "#ffffff");
             if (colorSchemeMeta) colorSchemeMeta.setAttribute("content", "light");
           }
         } catch (error) {

--- a/design-system/index.html
+++ b/design-system/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <meta name="theme-color" content="#000000" />
+    <meta name="theme-color" content="#ff453a" />
     <meta name="color-scheme" content="dark" />
     <link rel="icon" href="/favicon.ico?v=8aef762bbe84" sizes="any" />
     <link rel="icon" type="image/png" href="/favicon.png?v=8aef762bbe84" />
@@ -49,9 +49,7 @@
           if (storedTheme === "light") {
             document.documentElement.dataset.theme = "light";
             document.documentElement.style.colorScheme = "light";
-            const themeColorMeta = document.querySelector('meta[name="theme-color"]');
             const colorSchemeMeta = document.querySelector('meta[name="color-scheme"]');
-            if (themeColorMeta) themeColorMeta.setAttribute("content", "#ffffff");
             if (colorSchemeMeta) colorSchemeMeta.setAttribute("content", "light");
           }
         } catch (error) {

--- a/drafts/resy-discovery-index-original.html
+++ b/drafts/resy-discovery-index-original.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <meta name="theme-color" content="#000000" />
+    <meta name="theme-color" content="#ff453a" />
     <meta name="color-scheme" content="dark" />
     <link rel="icon" href="/favicon.ico?v=8aef762bbe84" sizes="any" />
     <link rel="icon" type="image/png" href="/favicon.png?v=8aef762bbe84" />
@@ -106,9 +106,7 @@
           if (storedTheme === "light") {
             document.documentElement.dataset.theme = "light";
             document.documentElement.style.colorScheme = "light";
-            const themeColorMeta = document.querySelector('meta[name="theme-color"]');
             const colorSchemeMeta = document.querySelector('meta[name="color-scheme"]');
-            if (themeColorMeta) themeColorMeta.setAttribute("content", "#ffffff");
             if (colorSchemeMeta) colorSchemeMeta.setAttribute("content", "light");
           }
         } catch (error) {

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <meta name="theme-color" content="#000000" />
+    <meta name="theme-color" content="#ff453a" />
     <meta name="color-scheme" content="dark" />
     <link rel="icon" href="/favicon.ico?v=8aef762bbe84" sizes="any" />
     <link rel="icon" type="image/png" href="/favicon.png?v=8aef762bbe84" />
@@ -87,9 +87,7 @@
           if (storedTheme === "light") {
             document.documentElement.dataset.theme = "light";
             document.documentElement.style.colorScheme = "light";
-            const themeColorMeta = document.querySelector('meta[name="theme-color"]');
             const colorSchemeMeta = document.querySelector('meta[name="color-scheme"]');
-            if (themeColorMeta) themeColorMeta.setAttribute("content", "#ffffff");
             if (colorSchemeMeta) colorSchemeMeta.setAttribute("content", "light");
           }
         } catch (error) {

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <meta name="theme-color" content="#000000" />
+    <meta name="theme-color" content="#ff453a" />
     <meta name="color-scheme" content="dark" />
     <link rel="icon" href="/favicon.ico?v=8aef762bbe84" sizes="any" />
     <link rel="icon" type="image/png" href="/favicon.png?v=8aef762bbe84" />
@@ -49,9 +49,7 @@
           if (storedTheme === "light") {
             document.documentElement.dataset.theme = "light";
             document.documentElement.style.colorScheme = "light";
-            const themeColorMeta = document.querySelector('meta[name="theme-color"]');
             const colorSchemeMeta = document.querySelector('meta[name="color-scheme"]');
-            if (themeColorMeta) themeColorMeta.setAttribute("content", "#ffffff");
             if (colorSchemeMeta) colorSchemeMeta.setAttribute("content", "light");
           }
         } catch (error) {

--- a/work/ai-quota/index.html
+++ b/work/ai-quota/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <meta name="theme-color" content="#000000" />
+    <meta name="theme-color" content="#ff453a" />
     <meta name="color-scheme" content="dark" />
     <link rel="icon" href="/favicon.ico?v=8aef762bbe84" sizes="any" />
     <link rel="icon" type="image/png" href="/favicon.png?v=8aef762bbe84" />
@@ -106,9 +106,7 @@
           if (storedTheme === "light") {
             document.documentElement.dataset.theme = "light";
             document.documentElement.style.colorScheme = "light";
-            const themeColorMeta = document.querySelector('meta[name="theme-color"]');
             const colorSchemeMeta = document.querySelector('meta[name="color-scheme"]');
-            if (themeColorMeta) themeColorMeta.setAttribute("content", "#ffffff");
             if (colorSchemeMeta) colorSchemeMeta.setAttribute("content", "light");
           }
         } catch (error) {

--- a/work/index.html
+++ b/work/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <meta name="theme-color" content="#000000" />
+    <meta name="theme-color" content="#ff453a" />
     <meta name="color-scheme" content="dark" />
     <link rel="icon" href="/favicon.ico?v=8aef762bbe84" sizes="any" />
     <link rel="icon" type="image/png" href="/favicon.png?v=8aef762bbe84" />
@@ -49,9 +49,7 @@
           if (storedTheme === "light") {
             document.documentElement.dataset.theme = "light";
             document.documentElement.style.colorScheme = "light";
-            const themeColorMeta = document.querySelector('meta[name="theme-color"]');
             const colorSchemeMeta = document.querySelector('meta[name="color-scheme"]');
-            if (themeColorMeta) themeColorMeta.setAttribute("content", "#ffffff");
             if (colorSchemeMeta) colorSchemeMeta.setAttribute("content", "light");
           }
         } catch (error) {

--- a/work/resy-discovery/index.html
+++ b/work/resy-discovery/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <meta name="theme-color" content="#000000" />
+    <meta name="theme-color" content="#ff453a" />
     <meta name="color-scheme" content="dark" />
     <link rel="icon" href="/favicon.ico?v=8aef762bbe84" sizes="any" />
     <link rel="icon" type="image/png" href="/favicon.png?v=8aef762bbe84" />
@@ -106,9 +106,7 @@
           if (storedTheme === "light") {
             document.documentElement.dataset.theme = "light";
             document.documentElement.style.colorScheme = "light";
-            const themeColorMeta = document.querySelector('meta[name="theme-color"]');
             const colorSchemeMeta = document.querySelector('meta[name="color-scheme"]');
-            if (themeColorMeta) themeColorMeta.setAttribute("content", "#ffffff");
             if (colorSchemeMeta) colorSchemeMeta.setAttribute("content", "light");
           }
         } catch (error) {

--- a/work/resy-search-ai/index.html
+++ b/work/resy-search-ai/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <meta name="theme-color" content="#000000" />
+    <meta name="theme-color" content="#ff453a" />
     <meta name="color-scheme" content="dark" />
     <link rel="icon" href="/favicon.ico?v=8aef762bbe84" sizes="any" />
     <link rel="icon" type="image/png" href="/favicon.png?v=8aef762bbe84" />
@@ -106,9 +106,7 @@
           if (storedTheme === "light") {
             document.documentElement.dataset.theme = "light";
             document.documentElement.style.colorScheme = "light";
-            const themeColorMeta = document.querySelector('meta[name="theme-color"]');
             const colorSchemeMeta = document.querySelector('meta[name="color-scheme"]');
-            if (themeColorMeta) themeColorMeta.setAttribute("content", "#ffffff");
             if (colorSchemeMeta) colorSchemeMeta.setAttribute("content", "light");
           }
         } catch (error) {

--- a/work/sendmoi/index.html
+++ b/work/sendmoi/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <meta name="theme-color" content="#000000" />
+    <meta name="theme-color" content="#ff453a" />
     <meta name="color-scheme" content="dark" />
     <link rel="icon" href="/favicon.ico?v=8aef762bbe84" sizes="any" />
     <link rel="icon" type="image/png" href="/favicon.png?v=8aef762bbe84" />
@@ -106,9 +106,7 @@
           if (storedTheme === "light") {
             document.documentElement.dataset.theme = "light";
             document.documentElement.style.colorScheme = "light";
-            const themeColorMeta = document.querySelector('meta[name="theme-color"]');
             const colorSchemeMeta = document.querySelector('meta[name="color-scheme"]');
-            if (themeColorMeta) themeColorMeta.setAttribute("content", "#ffffff");
             if (colorSchemeMeta) colorSchemeMeta.setAttribute("content", "light");
           }
         } catch (error) {


### PR DESCRIPTION
## Summary

- set the site-wide `theme-color` to the brand red `#ff453a`
- keep browser chrome red in both light and dark site themes
- apply the setting across static pages, case studies, and generated blog templates

## Impact

Safari and other supporting browsers can tint their browser chrome with the site accent color.

## Validation

- `git diff --check`
- `npm run build`
- confirmed generated blog pages contain the red `theme-color`