### PR TITLE
Restore Safari body tinting

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -121,11 +121,10 @@ body {
   margin: 0;
   min-height: 100%;
   scroll-behavior: smooth;
-  background: var(--bg);
 }
 
 body {
-  background: var(--bg);
+  background: var(--accent);
   color: var(--fg);
   font-family: "Sohne", "SF Pro Text", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Helvetica Neue",
     "Arial Nova", "Arial", sans-serif;
@@ -245,6 +244,7 @@ a:focus-visible {
   position: relative;
   min-height: 100vh;
   padding-left: 0;
+  background: var(--bg);
 }
 
 .page::before {

--- a/assets/css/work-case-study.css
+++ b/assets/css/work-case-study.css
@@ -140,11 +140,10 @@ html,
 body {
   margin: 0;
   min-height: 100%;
-  background: var(--bg);
 }
 
 body {
-  background: var(--bg);
+  background: var(--accent);
   color: var(--fg);
   font-family: "Sohne", "SF Pro Text", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Helvetica Neue",
     "Arial Nova", "Arial", sans-serif;
@@ -252,6 +251,7 @@ body.work-theme-aiquota {
 .work-page {
   position: relative;
   min-height: 100vh;
+  background: var(--bg);
 }
 
 .work-page::before {


### PR DESCRIPTION
## Summary

- restore the old-site red document background used by Safari Technology Preview for browser tinting
- keep the visible page black or white through the full-height page wrappers
- apply the same structure to homepage and subpage styles

## Validation

- `git diff --check`
- `npm run build`