### PR TITLE
Report the last complete week in the GA4 summary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ node_modules/
 /admin/
 /feed.xml
 /sitemap.xml
+
+# Python bytecode cache
+__pycache__/
+*.pyc

--- a/scripts/check-ga4-analytics.sh
+++ b/scripts/check-ga4-analytics.sh
@@ -118,5 +118,9 @@ expect_pattern "scripts/ga4-weekly-report.py" 'value=r"^(www\.)?nieder\.me$"' \
   "Expected the weekly GA4 report to include only nieder.me production hosts."
 expect_pattern "scripts/ga4-weekly-report.py" "dimension_filter=PRODUCTION_HOST_FILTER" \
   "Expected every weekly GA4 query to use the production hostname filter."
+expect_pattern "scripts/ga4-weekly-report.py" "week_end    = this_monday - timedelta(days=1)" \
+  "Expected the weekly GA4 report to end on the last complete Sunday."
+expect_no_pattern "scripts/ga4-weekly-report.py" "run_report(week_start, today," \
+  "Expected the weekly GA4 report to query the last complete week, not the current partial one."
 
 echo "GA4 analytics checks passed."

--- a/scripts/ga4-weekly-report.py
+++ b/scripts/ga4-weekly-report.py
@@ -57,10 +57,15 @@ credentials = service_account.Credentials.from_service_account_file(
 )
 client = BetaAnalyticsDataClient(credentials=credentials)
 
-today      = date.today()
-week_start = today - timedelta(days=today.weekday())
-lw_start   = week_start - timedelta(days=7)
-lw_end     = week_start - timedelta(days=1)
+today       = date.today()
+# The cron fires Monday morning, so "this week" is only a few hours old.
+# Report the last complete Mon–Sun window instead, and compare it against
+# the week before that.
+this_monday = today - timedelta(days=today.weekday())
+week_start  = this_monday - timedelta(days=7)
+week_end    = this_monday - timedelta(days=1)
+lw_start    = week_start - timedelta(days=7)
+lw_end      = week_start - timedelta(days=1)
 
 PRODUCTION_HOST_FILTER = FilterExpression(
     filter=Filter(
@@ -88,26 +93,26 @@ by_sessions = lambda name="sessions": [
     OrderBy(metric=OrderBy.MetricOrderBy(metric_name=name), desc=True)
 ]
 
-totals      = run_report(week_start, today, [],
+totals      = run_report(week_start, week_end, [],
                          ["sessions", "activeUsers", "screenPageViews", "newUsers"])
-overview    = run_report(week_start, today, ["date"],
+overview    = run_report(week_start, week_end, ["date"],
                          ["sessions", "activeUsers", "screenPageViews"], limit=7,
                          order_by=[OrderBy(dimension=OrderBy.DimensionOrderBy(dimension_name="date"))])
 lw_overview = run_report(lw_start, lw_end, [],
                          ["sessions", "activeUsers", "screenPageViews", "newUsers"])
-top_pages   = run_report(week_start, today, ["pagePath"],
+top_pages   = run_report(week_start, week_end, ["pagePath"],
                          ["screenPageViews", "activeUsers"], limit=10,
                          order_by=by_sessions("screenPageViews"))
-sources     = run_report(week_start, today, ["sessionSource", "sessionMedium"],
+sources     = run_report(week_start, week_end, ["sessionSource", "sessionMedium"],
                          ["screenPageViews", "activeUsers"], limit=10,
                          order_by=by_sessions("screenPageViews"))
-countries   = run_report(week_start, today, ["country"],
+countries   = run_report(week_start, week_end, ["country"],
                          ["sessions", "activeUsers"], limit=8, order_by=by_sessions())
-devices     = run_report(week_start, today, ["deviceCategory"],
+devices     = run_report(week_start, week_end, ["deviceCategory"],
                          ["sessions", "activeUsers"], order_by=by_sessions())
-new_ret     = run_report(week_start, today, ["newVsReturning"],
+new_ret     = run_report(week_start, week_end, ["newVsReturning"],
                          ["sessions", "activeUsers"], order_by=by_sessions())
-landing     = run_report(week_start, today, ["landingPagePlusQueryString"],
+landing     = run_report(week_start, week_end, ["landingPagePlusQueryString"],
                          ["sessions", "bounceRate", "screenPageViews"], limit=12,
                          order_by=by_sessions())
 
@@ -171,7 +176,7 @@ lines = []
 W = 52
 
 lines += [f"{'═'*W}",
-          f"  nieder.me  ·  {week_start} → {today}",
+          f"  nieder.me  ·  {week_start} → {week_end}",
           f"{'═'*W}", ""]
 
 lines += [f"  {'Sessions:':<14}{tw_s:>6,}{delta(tw_s, lw_s)}",


### PR DESCRIPTION
## The zeros

Monday's analytics report came through with `0` across the board and `−100% vs last wk` on every metric.

The window math was the cause:

```python
week_start = today - timedelta(days=today.weekday())
totals     = run_report(week_start, today, ...)
```

The workflow fires `0 13 * * 1` — Monday 9am ET. On a Monday `today.weekday()` is `0`, so `week_start == today` and the "weekly" report queried a single partial day: midnight to 9am of a week that had barely started. Meanwhile `lw_overview` still covered the full prior Mon–Sun week, so each delta compared a few quiet hours against seven days and reported `−100%`. GA4's same-day processing lag made the near-empty result even emptier.

## The fix

Query the last **complete** Mon–Sun window, and compare it against the week before that:

```python
this_monday = today - timedelta(days=today.weekday())
week_start  = this_monday - timedelta(days=7)
week_end    = this_monday - timedelta(days=1)
lw_start    = week_start - timedelta(days=7)
lw_end      = week_start - timedelta(days=1)
```

All eight `run_report` calls and the report header now end at `week_end` instead of `today`. Both sides of every delta are full seven-day windows, and no query touches the current day, so the same-day lag is out of the picture.

A run on Monday 2026-08-03 now reports `2026-07-27 → 2026-08-02` against `2026-07-20 → 2026-07-26`. A manual `workflow_dispatch` mid-week reports that same closed week rather than a partial one — deliberate, so an ad-hoc run and the scheduled run agree.

## Guard

Two assertions added to `scripts/check-ga4-analytics.sh`, alongside the existing hostname-filter checks: the window must end on the last complete Sunday, and no query may pass `today` as its end date.

## Testing

- `bash scripts/check-ga4-analytics.sh` → passes
- `python3 -m py_compile scripts/ga4-weekly-report.py` → clean
- Simulated the window math for runs on Mon/Wed/Sun; each resolves to the same closed `2026-07-27 → 2026-08-02` week

Live GA4 output isn't verified here — the query needs `GA4_SERVICE_KEY`, which this session doesn't hold. The date arithmetic is what changed; the queries themselves are untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PKqtixf5cNfxinSsmtJL94)_